### PR TITLE
#15 tidy: add a preprocessor define for the test programs location

### DIFF
--- a/Tests/ControllerTest/CMakeLists.txt
+++ b/Tests/ControllerTest/CMakeLists.txt
@@ -14,4 +14,5 @@ target_link_libraries(${exe_name} PRIVATE
   TestControllers
 )
 
+target_compile_definitions(${exe_name} PRIVATE PROGRAMS_DIR=\"${CMAKE_SOURCE_DIR}/Tests/Programs/\")
 set_target_properties(${exe_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)

--- a/Tests/ControllerTest/source/ControllerTest.cpp
+++ b/Tests/ControllerTest/source/ControllerTest.cpp
@@ -48,7 +48,7 @@ namespace MachEmu::Tests
 		(
 			//load one byte compliment carry program into memory
 			//cppcheck-suppress unknownMacro
-			memoryController_->Load ("../../../Tests/Programs/cmc.bin", 0);
+			memoryController_->Load (PROGRAMS_DIR"cmc.bin", 0);
 		);
 	}
 
@@ -57,7 +57,7 @@ namespace MachEmu::Tests
 		EXPECT_ANY_THROW
 		(
 			//load three byte compliment accumulator program starting at the end of memory, this should throw
-			memoryController_->Load("../../../Tests/Programs/cma.bin", static_cast<uint16_t>(memoryController_->Size() - 1));
+			memoryController_->Load(PROGRAMS_DIR"cma.bin", static_cast<uint16_t>(memoryController_->Size() - 1));
 		);
 	}
 
@@ -80,7 +80,7 @@ namespace MachEmu::Tests
 
 		EXPECT_NO_THROW
 		(
-			memoryController_->Load("../../../Tests/Programs/cmc.bin", 0x00);
+			memoryController_->Load(PROGRAMS_DIR"cmc.bin", 0x00);
 			value = memoryController_->Read(0x00);
 		);
 

--- a/Tests/MachineTest/CMakeLists.txt
+++ b/Tests/MachineTest/CMakeLists.txt
@@ -23,5 +23,6 @@ target_link_libraries(${exe_name} PRIVATE
   TestControllers
 )
 
+target_compile_definitions(${exe_name} PRIVATE PROGRAMS_DIR=\"${CMAKE_SOURCE_DIR}/Tests/Programs/\")
 set_target_properties(${exe_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 # Leave a new line here on purpose as the sdk appends a target_link_directories command

--- a/Tests/MachineTest/source/MachineTest.cpp
+++ b/Tests/MachineTest/source/MachineTest.cpp
@@ -40,7 +40,6 @@ namespace MachEmu::Tests
 		static std::shared_ptr<MemoryController> memoryController_;
 		static std::shared_ptr<IController> ioController_;
 		static std::unique_ptr<IMachine> machine_;
-		static const inline std::filesystem::path directory_ = "../../../Tests/Programs";
 	public:
 		static void SetUpTestCase();
 		void SetUp();
@@ -90,17 +89,14 @@ namespace MachEmu::Tests
 		);
 	}
 
-/*
 	TEST_F(MachineTest, Run)
 	{
 		EXPECT_NO_THROW
 		(
-			auto path = directory_;
-			memoryController_->Load(path /= "cmc.bin", 0x00);
+			memoryController_->Load(PROGRAMS_DIR"cmc.bin", 0x00);
 			machine_->SetMemoryController(memoryController_);
 			machine_->SetIoController(ioController_);
 			machine_->Run();
 		);
 	}
-*/
 } // namespace MachEmu::Tests


### PR DESCRIPTION
A define has been added to all of the CMakeLists of the tests which require the use of the test programs.
The new preprocessor define 'PROGRAMS_DIR' now prefixes all program names. Currently it is set to ${CMAKE_SOURCE_DIR}/Tests/Programs 