### PR TITLE
#39 feat: add version api method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,9 @@ set(bugfix 0)
 
 project(mach-emu VERSION ${major}.${minor}.${bugfix})
 
+set(machEmuVersion ${CMAKE_PROJECT_VERSION})
+
 if(CMAKE_COMPILER_IS_GNUCXX)
-    set(machEmuVersion ${CMAKE_PROJECT_VERSION})
     set(STD_MODULES bitset chrono cstdint filesystem functional memory string string_view thread vector)
     include(${CMAKE_SOURCE_DIR}/CMakeIncludes/stdModules.cmake)
 endif()

--- a/Machine/CMakeLists.txt
+++ b/Machine/CMakeLists.txt
@@ -46,6 +46,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 	target_compile_options(${lib_name} PRIVATE -fvisibility=hidden)
 endif()
 
+target_compile_definitions(${lib_name} PRIVATE ${lib_name}_VERSION=\"${machEmuVersion}\")
 target_include_directories(${lib_name} PRIVATE ${CMAKE_SOURCE_DIR}/Base/${include_dir})
 target_include_directories(${lib_name} PRIVATE ${CMAKE_SOURCE_DIR}/Controller/${include_dir})
 target_include_directories(${lib_name} PRIVATE ${CMAKE_SOURCE_DIR}/Machine/${include_dir})

--- a/Machine/include/Machine/MachineFactory.h
+++ b/Machine/include/Machine/MachineFactory.h
@@ -24,6 +24,7 @@ SOFTWARE.
 #define MACHINE_FACTORY_H
 
 #include <memory>
+#include <string_view>
 #include "IMachine.h"
 
 #ifdef _WINDOWS
@@ -42,7 +43,26 @@ SOFTWARE.
 
 namespace MachEmu
 {
-	/** Create a machine.
+	/**
+		The shared library version
+
+		@return A string view containing the current version, in a format
+				described by [semantic versioning](https://semver.org/)
+
+				```
+				<major>"."<minor>"."<patch>
+				<major>"."<minor>"."<patch>"-"<pre-release>
+				<major>"."<minor>"."<patch>"+"<build>
+				<major>"."<minor>"."<patch>"-"<pre-release>"+"<build>
+				```
+
+		@remark Available since 1.4.0.
+
+		@remark	Version 1.3.0 is implied when this method is not available.
+	*/
+	DLL_EXP_IMP std::string_view Version();
+	
+	/** Create a machine
 	
 		Build a machine based on the Intel 8080 cpu.
 

--- a/Machine/source/MachineFactory.cpp
+++ b/Machine/source/MachineFactory.cpp
@@ -28,6 +28,11 @@ import Machine;
 
 namespace MachEmu
 {
+	std::string_view Version()
+	{
+		return MachEmu_VERSION;
+	}
+
 	//cppcheck-suppress unusedFunction
 	std::unique_ptr<IMachine> Make8080Machine()
 	{


### PR DESCRIPTION
A Version method has been added to the Machine Factory which is returned as a string_view. The version is set in the root CMakeLists file and is passed to the machine project via the MachEmu_VERSION definition.