### PR TITLE
#53 chore: method deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Added json config file support.
 * Added interrupt frequency config option.
 * Added cpu type config option.
+* Added run asynchronous config option.
+* Deprecated IMachine::GetState.
+* Deprecated IMachine::SetClockResolution.
 
 1.3.0 [29/01/24]
 * Added CMake support.

--- a/Machine/include/Machine/MachineFactory.h
+++ b/Machine/include/Machine/MachineFactory.h
@@ -65,11 +65,11 @@ namespace MachEmu
 	
 		Build a machine based on the Intel 8080 cpu.
 
-		@return		A unique i8080 machine pointer that can be loaded with memory and io controllers.
+		@return			A unique i8080 machine pointer that can be loaded with memory and io controllers.
 	
-		@remark		Deprecated, please use MakeMachine
+		@deprecated		since 1.4.0
 	
-		@see		MakeMachine
+		@see			MakeMachine
 	*/
 	DLL_EXP_IMP [[deprecated("Will be removed in v2.0.0, please use MakeMachine which is more flexible")]] std::unique_ptr<IMachine> Make8080Machine();
 
@@ -95,7 +95,7 @@ namespace MachEmu
 							| runAsync | bool   | true             | IMachine::Run will be launced on a separate thread                 |
 							|          |        | false (default)  | IMachine:Run() will be run on the current thread                   |
 							| isrFreq  | double | 0 (default)      | Service interrupts at the completion of each instruction           |
-							|          |        | 1                | Service interrupts at after each clock tick                        |
+							|          |        | 1                | Service interrupts after each clock tick                           |
 							|          |        | n                | Service interrupts frequency, example: 0.5 - twice per clock tick  |
 
 		@return		A unique machine pointer that can be loaded with memory and io controllers.

--- a/Machine/module/Machine.ixx
+++ b/Machine/module/Machine.ixx
@@ -51,8 +51,10 @@ namespace MachEmu
 		std::shared_ptr<IController> ioController_;
 		SystemBus<uint16_t, uint8_t, 8> systemBus_;
 		Opt opt_;
+		//cppcheck-suppress unusedStructMember
 		int64_t ticksPerIsr_{};
 		std::future<int64_t> fut_;
+		//cppcheck-suppress unusedStructMember
 		bool running_{};
 
 		void ProcessControllers(const SystemBus<uint16_t, uint8_t, 8>&& systemBus);
@@ -89,6 +91,12 @@ namespace MachEmu
 			@see IMachine::SetOpts
 		*/
 		ErrorCode SetOptions(const char* options);
+
+		/** Get the machine state
+
+			@see IMachine::GetState
+		*/
+		std::string GetState() const;
 
 		/** Set the clock resolution.
 		

--- a/Machine/source/Machine.cpp
+++ b/Machine/source/Machine.cpp
@@ -72,7 +72,7 @@ namespace MachEmu
 			throw std::runtime_error("The machine is running");
 		}
 
-		auto err = ErrorCode::NoError;
+		ErrorCode err;
 
 		if (options == nullptr)
 		{
@@ -260,6 +260,11 @@ namespace MachEmu
 		}
 
 		ioController_ = controller;
+	}
+
+	std::string Machine::GetState() const
+	{
+		return "";
 	}
 
 	std::unique_ptr<uint8_t[]> Machine::GetState(int* size) const

--- a/Tests/MachineTest/source/MachineTest.cpp
+++ b/Tests/MachineTest/source/MachineTest.cpp
@@ -90,7 +90,7 @@ namespace MachEmu::Tests
 			machine_->Run(0x100);
 		);
 
-		return machine_->GetState();
+		return machine_->GetState(nullptr);
 	}
 
 	void MachineTest::CheckStatus(uint8_t status, bool zero, bool sign, bool parity, bool auxCarry, bool carry)
@@ -171,7 +171,7 @@ namespace MachEmu::Tests
 
 		EXPECT_ANY_THROW
 		(
-			machine_->GetState();
+			machine_->GetState(nullptr);
 		);
 
 		// Since we are running async we need to wait for completion
@@ -201,7 +201,7 @@ namespace MachEmu::Tests
 
 		EXPECT_NO_THROW
 		(
-			machine_->GetState();
+			machine_->GetState(nullptr);
 		);
 	}
 


### PR DESCRIPTION
The following methods have been deprecated:

- IMachine::SetClockResolution
- IMachine::GetState

The change log has been updated along with all other relevant documentation.