### PR TITLE
#74 feat: add ram/rom offset/size to libOpt

### DIFF
--- a/Opt/CMakeLists.txt
+++ b/Opt/CMakeLists.txt
@@ -44,4 +44,3 @@ endif()
 target_include_directories(${lib_name} PRIVATE ${CMAKE_SOURCE_DIR}/Base/${include_dir})
 target_include_directories(${lib_name} PRIVATE ${CMAKE_SOURCE_DIR}/${lib_name}/${include_dir})
 target_link_libraries(${lib_name} PRIVATE nlohmann_json::nlohmann_json)
-

--- a/Opt/include/Opt/Opt.h
+++ b/Opt/include/Opt/Opt.h
@@ -78,6 +78,30 @@ namespace MachEmu
 			*/
 			double ISRFreq() const;
 
+			/**	The ram offset
+			
+				@return The offset in bytes from the start of memory to the ram.
+			*/
+			uint16_t RamOffset() const;
+
+			/**	The ram size
+
+				@return The size in bytes of the ram.
+			*/
+			uint16_t RamSize() const;
+
+			/**	The rom offset
+
+				@return The offset in bytes from the start of memory to the rom.
+			*/
+			uint16_t RomOffset() const;
+
+			/**	The rom offset
+
+				@return The size in bytes of the ram.
+			*/
+			uint16_t RomSize() const;
+
 			/** Machine run mode
 
 				True for asynchronous, false for synchronous.

--- a/Opt/source/Opt.cpp
+++ b/Opt/source/Opt.cpp
@@ -15,9 +15,9 @@ namespace MachEmu
 		}
 
 #ifdef ENABLE_ZLIB		
-		std::string defaults = R"({"clockResolution":-1,"encoder":"base64","compressor":"zlib","isrFreq":0,"runAsync":false})";
+		std::string defaults = R"({"clockResolution":-1,"compressor":"zlib","encoder":"base64","isrFreq":0,"ramOffset":0,"ramSize":0,"romOffset":0,"romSize":0,"runAsync":false})";
 #else
-		std::string defaults = R"({"clockResolution":-1,"encoder":"base64","compressor":"none","isrFreq":0,"runAsync":false})";
+		std::string defaults = R"({"clockResolution":-1,"compressor":"none","encoder":"base64","isrFreq":0,"ramOffset":0,"ramSize":0,"romOffset":0,"romSize":0,"runAsync":false})";
 #endif
 		*json_ = nlohmann::json::parse(defaults);
 	}
@@ -109,6 +109,26 @@ namespace MachEmu
 	double Opt::ISRFreq() const
 	{
 		return (*json_)["isrFreq"].get<double>();
+	}
+
+	uint16_t Opt::RamOffset() const
+	{
+		return (*json_)["ramOffset"].get<uint16_t>();
+	}
+
+	uint16_t Opt::RamSize() const
+	{
+		return (*json_)["ramSize"].get<uint16_t>();
+	}
+
+	uint16_t Opt::RomOffset() const
+	{
+		return (*json_)["romOffset"].get<uint16_t>();
+	}
+
+	uint16_t Opt::RomSize() const
+	{
+		return (*json_)["romSize"].get<uint16_t>();
 	}
 
 	bool Opt::RunAsync() const


### PR DESCRIPTION
The following options have been added to libOpt:

- `ramOffset`
- `ramSize`
- `romOffset`
- `romSize`