### PR TITLE
#100 fix: drop additional save/load requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-1.5.1
+1.5.1 [22/04/16]
 * Fixed api compatibility break in 1.5.0.
+* Drop load/save requests while a load/save
+  is in progress.
 
 1.5.0 [19/04/24]
 * Added Machine interface method `OnLoad`.

--- a/Machine/include/Machine/IMachine.h
+++ b/Machine/include/Machine/IMachine.h
@@ -233,12 +233,8 @@ namespace MachEmu
 			@remark						The function parameter onSave will be called from a different thread from which this
 										method was called if the runAsync or saveAsync config options have been specified.
 
-			@remark						Save requests should not be a frequent operation, therefore (by design) each save
-										request will be processed before moving to the next one, ie, if a save request is
-										being processed while another save has been requested, the thread processing the
-										current save request will block until it has completed before moving onto the next
-										one, ie, save requests are not queued (don't spam the ISR::Save interrupt).
-
+			@remark						Save requests are not queued. When a save is in progress, additional save interrupts
+										will be ignored.
 			@since	version 1.5.0
 		*/
 		virtual void OnSave(std::function<void(const char* json)>&& onSave) = 0;
@@ -265,11 +261,8 @@ namespace MachEmu
 			@remark						When the format of the returned json string is invalid or a load error occurs the state
 										of the machine shall remain unchanged.
 
-			@remark						Load requests should not be a frequent operation, therefore (by design) each load
-										request will be processed before moving to the next one, ie, if a load request is
-										being processed while another load has been requested, the thread processing the
-										current load request will block until it has completed before moving onto the next
-										one, ie, load requests are not queued (don't spam the ISR::Load interrupt).
+			@remark						Load requests are not queued. When a load is in progress, additional load interrupts
+										will be ignored.
 
 			@todo						Log when errors occur.
 

--- a/Tests/MachineTest/source/MachineTest.cpp
+++ b/Tests/MachineTest/source/MachineTest.cpp
@@ -341,9 +341,16 @@ namespace MachEmu::Tests
 				EXPECT_EQ(3, cpmIoController->Message().find("CPU IS OPERATIONAL"));
 			}
 
-			ASSERT_EQ(saveStates.size(), 3);
+			// When we are in the middle of a save when another save is requested it will be dropped.
+			// This may or may not happen depending on how fast the first save takes to complete.
+			ASSERT_TRUE(saveStates.size() == 3 || saveStates.size() == 2);
 			EXPECT_STREQ(R"({"cpu":{"uuid":"O+hPH516S3ClRdnzSRL8rQ==","registers":{"a":19,"b":19,"c":0,"d":19,"e":0,"h":19,"l":0,"s":86},"pc":1236,"sp":1981},"memory":{"uuid":"zRjYZ92/TaqtWroc666wMQ==","rom":"JXg8/M+WvmCGVMmH7xr/0g==","ram":{"encoder":"base64","compressor":"zlib","size":256,"bytes":"eJwLZRhJQJqZn5mZ+TvTa6b7TJeZjjIxMAAAfY0E7w=="}}})", saveStates[0].c_str());
-			EXPECT_STREQ(saveStates[1].c_str(), saveStates[2].c_str());
+			EXPECT_STREQ(R"({"cpu":{"uuid":"O+hPH516S3ClRdnzSRL8rQ==","registers":{"a":170,"b":170,"c":9,"d":170,"e":170,"h":170,"l":170,"s":86},"pc":2,"sp":1981},"memory":{"uuid":"zRjYZ92/TaqtWroc666wMQ==","rom":"JXg8/M+WvmCGVMmH7xr/0g==","ram":{"encoder":"base64","compressor":"zlib","size":256,"bytes":"eJw7w2ZczrCXnWFkAGlmfmZm5u9MYauCGFet2sXGwAAAYNgG1w=="}}})", saveStates[1].c_str());
+
+			if (saveStates.size() == 3)
+			{
+				EXPECT_STREQ(R"({"cpu":{"uuid":"O+hPH516S3ClRdnzSRL8rQ==","registers":{"a":170,"b":170,"c":9,"d":170,"e":170,"h":170,"l":170,"s":86},"pc":2,"sp":1981},"memory":{"uuid":"zRjYZ92/TaqtWroc666wMQ==","rom":"JXg8/M+WvmCGVMmH7xr/0g==","ram":{"encoder":"base64","compressor":"zlib","size":256,"bytes":"eJw7w2ZczrCXnWFkAGlmfmZm5u9MYauCGFet2sXGwAAAYNgG1w=="}}})", saveStates[2].c_str());
+			}
 		);
 	}
 


### PR DESCRIPTION
Don't block if additional save/load requests are made while a save/load is in progress. This prevents the machine thread from stuttering.