### PR TITLE
#105 fix: make sure the json entries are valid before applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.5.2
+* Perform all compatibility checks before
+  attempting to restore the machine state.
+
 1.5.1 [22/04/16]
 * Fixed api compatibility break in 1.5.0.
 * Drop load/save requests while a load/save

--- a/Cpu/source/8080.cpp
+++ b/Cpu/source/8080.cpp
@@ -335,16 +335,29 @@ void Intel8080::Load(const std::string&& str)
 		throw std::runtime_error("Incompatible cpu");
 	}
 
-	a_ = json["registers"]["a"].get<uint8_t>();
-	b_ = json["registers"]["b"].get<uint8_t>();
-	c_ = json["registers"]["c"].get<uint8_t>();
-	d_ = json["registers"]["d"].get<uint8_t>();
-	e_ = json["registers"]["e"].get<uint8_t>();
-	h_ = json["registers"]["h"].get<uint8_t>();
-	l_ = json["registers"]["l"].get<uint8_t>();
-	status_ = json["registers"]["s"].get<uint8_t>();
-	pc_ = json["pc"].get<uint16_t>();
-	sp_ = json["sp"].get<uint16_t>();
+	// Make sure everything exists and is copied out
+	auto a = json["registers"]["a"].get<uint8_t>();
+	auto b = json["registers"]["b"].get<uint8_t>();
+	auto c = json["registers"]["c"].get<uint8_t>();
+	auto d = json["registers"]["d"].get<uint8_t>();
+	auto e = json["registers"]["e"].get<uint8_t>();
+	auto h = json["registers"]["h"].get<uint8_t>();
+	auto l = json["registers"]["l"].get<uint8_t>();
+	auto s = json["registers"]["s"].get<uint8_t>();
+	auto pc = json["pc"].get<uint16_t>();
+	auto sp = json["sp"].get<uint16_t>();
+
+	// Restore the state of the cpu
+	a_ = a;
+	b_ = b;
+	c_ = c;
+	d_ = d;
+	e_ = e;
+	h_ = h;
+	l_ = l;
+	status_ = s;
+	pc_ = pc;
+	sp_ = sp;
 }
 
 std::string Intel8080::Save() const

--- a/Machine/source/Machine.cpp
+++ b/Machine/source/Machine.cpp
@@ -193,7 +193,6 @@ namespace MachEmu
 							throw std::runtime_error("Incompatible memory controller");
 						}
 
-						cpu_->Load(json["cpu"].dump());
 						std::vector<uint8_t> rom(opt_.RomSize());
 
 						for (auto addr = opt_.RomOffset(); addr < opt_.RomSize(); addr++)
@@ -223,7 +222,9 @@ namespace MachEmu
 							throw std::runtime_error("Incompatible ram");
 						}
 
-						// write it back to memory
+						// Once all checks are complete, restore the cpu and the memory
+						cpu_->Load(json["cpu"].dump());
+
 						auto addr = opt_.RamOffset();
 
 						for (const auto& r : ram)


### PR DESCRIPTION
The cpu and the memory are only modified once all the state has been processed successfully.