### PR TITLE
#122 tidy: use a cmake include for python test deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Example command lines:
 1. `conan create . --build=missing`: build the mach_emu package, run the unit tests, export it to the conan cache and then run a basic test to confirm that the exported package can be used.
 2. `conan create . --build=missing --options=with_python=True`: same as 1 but will run the python unit tests, then run a basic test to confirm that the python module in the exported package can also be used.
 3. `conan create . --build=missing --options=with_zlib=False`: same as 1 but will disable zlib support. 
-4. `conan create . --build=missing --test_folder=""`: same as 1 but will not run the basic package tests (not recommended).
+4. `conan create . --build=missing --test-folder=""`: same as 1 but will not run the basic package tests (not recommended).
 5. `conan create . --build=missing --conf=tools.build:skip_test=True`: same as 1 but will skip running the unit tests.
 6. `conan create . --build=missing --options=with_i8080_test_suites=False`: same as 1 but will not run the i8080 test suites.
 

--- a/Tests/ConanPackageTest/CMakeLists.txt
+++ b/Tests/ConanPackageTest/CMakeLists.txt
@@ -1,36 +1,23 @@
 cmake_minimum_required(VERSION 3.25)
 project(MachEmuPackageTest CXX)
 
+if(MSVC)
+  set(buildType $<CONFIG>)
+else()
+  set(buildType ${CMAKE_BUILD_TYPE})
+endif()
+
 find_package(mach_emu CONFIG REQUIRED)
 
-if(ZLIB_BIN_DIR)
-    set(addZlibDllDir "import os\nos.add_dll_directory(\"${ZLIB_BIN_DIR}\")\n")
-endif()
-
-if(MACH_EMU_BIN_DIR OR ZLIB_BIN_DIR)
-    # command to prepend dll search path to machine test script
-    file(WRITE "source/MachEmuPackageTestDeps.py"
-    "# Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>\n\n\
-# Permission is hereby granted, free of charge, to any person obtaining a copy\n\
-# of this software and associated documentation files (the \"Software\"), to deal\n\
-# in the Software without restriction, including without limitation the rights\n\
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n\
-# copies of the Software, and to permit persons to whom the Software is\n\
-# furnished to do so, subject to the following conditions:\n\n\
-# The above copyright notice and this permission notice shall be included in all\n\
-# copies or substantial portions of the Software.\n\n\
-# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n\
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n\
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n\
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n\
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n\
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n\
-# SOFTWARE.\n\n\
-${addZlibDllDir}
-import sys\n\
-# absolute path to the C++ controller test module\n\
-sys.path.append(\"${MACH_EMU_BIN_DIR}\")")
-endif()
-
 add_executable(MachEmuPackageTest source/MachEmuPackageTest.cpp)
+
+if(DEFINED artifactsDir OR DEFINED zlibDllDir)
+    include(${CMAKE_SOURCE_DIR}/../MachineTest/pythonTestDeps.cmake)
+
+    add_custom_command(
+        TARGET MachEmuPackageTest POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/MachineTestDeps${buildType}.py ${CMAKE_CURRENT_SOURCE_DIR}/source/MachineTestDeps.py
+    )
+endif()
+
 target_link_libraries(MachEmuPackageTest mach_emu::mach_emu)

--- a/Tests/ConanPackageTest/conanfile.py
+++ b/Tests/ConanPackageTest/conanfile.py
@@ -23,9 +23,10 @@ class MachuEmuPackageTest(ConanFile):
         # Need to inform the python test app where the dependent shared libraries are located
         if self.dependencies["mach_emu"].options.with_python:
             if self.dependencies["mach_emu"].options.shared:
-                tc.variables["MACH_EMU_BIN_DIR"] = self.dependencies["mach_emu"].cpp_info.bindirs[0].replace("\\", "/")
+                tc.variables["artifactsDir"] = self.dependencies["mach_emu"].cpp_info.bindirs[0].replace("\\", "/")
             if self.settings.os == "Windows" and self.dependencies["mach_emu"].options.with_zlib and self.dependencies["zlib"].options.shared:
-                tc.variables["ZLIB_BIN_DIR"] = self.dependencies["zlib"].cpp_info.bindirs[0].replace("\\", "/")
+                tc.variables["zlibDllDir"] = self.dependencies["zlib"].cpp_info.bindirs[0].replace("\\", "/")
+            tc.variables["MachEmuPackageTest"] = True
 
         tc.generate()
 

--- a/Tests/ConanPackageTest/source/MachEmuPackageTest.py
+++ b/Tests/ConanPackageTest/source/MachEmuPackageTest.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import MachEmuPackageTestDeps
+import MachineTestDeps
 import os
 import sys
 

--- a/Tests/MachineTest/CMakeLists.txt
+++ b/Tests/MachineTest/CMakeLists.txt
@@ -28,43 +28,14 @@ SOURCE_GROUP("Source Files" FILES ${${exe_name}_source_files})
 
 add_executable(${exe_name} ${${exe_name}_source_files})
 
-if (MSVC)
-  if(enableZlib)
-    string(REPLACE "include" "bin" ZLIB_DLL_DIR ${ZLIB_INCLUDE_DIR})
-    set(addZlibDllDir "import os\nos.add_dll_directory(\"${ZLIB_DLL_DIR}\")\n")
-  endif()
+if(enablePythonModule STREQUAL ON)
+    include(pythonTestDeps.cmake)
+
+    add_custom_command(
+        TARGET ${exe_name} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/MachineTestDeps${buildType}.py ${CMAKE_CURRENT_SOURCE_DIR}/source/MachineTestDeps.py
+        )
 endif()
-
-# command to prepend dll search path to machine test script
-file(GENERATE OUTPUT "MachineTestDeps${buildType}.py" CONTENT
-"# Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>\n\n\
-# Permission is hereby granted, free of charge, to any person obtaining a copy\n\
-# of this software and associated documentation files (the \"Software\"), to deal\n\
-# in the Software without restriction, including without limitation the rights\n\
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n\
-# copies of the Software, and to permit persons to whom the Software is\n\
-# furnished to do so, subject to the following conditions:\n\n\
-# The above copyright notice and this permission notice shall be included in all\n\
-# copies or substantial portions of the Software.\n\n\
-# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n\
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n\
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n\
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n\
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n\
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n\
-# SOFTWARE.\n\n\
-${addZlibDllDir}
-import sys\n\
-# absolute path to Python controller test modules\n\
-sys.path.append(\"${CMAKE_SOURCE_DIR}/Tests/TestControllers/source\")\n\
-# absolute path to the C++ controller test module\n\
-sys.path.append(\"${artifactsDir}/${runtimeDir}\")\n\
-programsDir = \"${CMAKE_SOURCE_DIR}/Tests/Programs/\"\n")
-
-add_custom_command(
-  TARGET ${exe_name} POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/MachineTestDeps${buildType}.py ${CMAKE_CURRENT_SOURCE_DIR}/source/MachineTestDeps.py
-)
 
 target_link_libraries(${exe_name} PRIVATE
   GTest::GTest

--- a/Tests/MachineTest/pythonTestDeps.cmake
+++ b/Tests/MachineTest/pythonTestDeps.cmake
@@ -1,0 +1,31 @@
+if(DEFINED zlibDllDir)
+    set(addZlibDllDir "import os\nos.add_dll_directory(\"${zlibDllDir}\")\n")
+endif()
+
+if (NOT DEFINED MachEmuPackageTest)
+   set(unitTestDeps "# absolute path to Python controller test modules\nsys.path.append(\"${CMAKE_SOURCE_DIR}/Tests/TestControllers/source\")\nprogramsDir = \"${CMAKE_SOURCE_DIR}/Tests/Programs/\"\n")
+endif()
+
+# command to prepend dll search path to machine test script
+file(GENERATE OUTPUT "MachineTestDeps${buildType}.py" CONTENT
+"# Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>\n\n\
+# Permission is hereby granted, free of charge, to any person obtaining a copy\n\
+# of this software and associated documentation files (the \"Software\"), to deal\n\
+# in the Software without restriction, including without limitation the rights\n\
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n\
+# copies of the Software, and to permit persons to whom the Software is\n\
+# furnished to do so, subject to the following conditions:\n\n\
+# The above copyright notice and this permission notice shall be included in all\n\
+# copies or substantial portions of the Software.\n\n\
+# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n\
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n\
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n\
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n\
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n\
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n\
+# SOFTWARE.\n\n\
+${addZlibDllDir}
+import sys\n\
+# absolute path to the C++ controller test module\n\
+sys.path.append(\"${artifactsDir}/${runtimeDir}\")\n\
+${unitTestDeps}")

--- a/conanfile.py
+++ b/conanfile.py
@@ -50,6 +50,7 @@ class MachEmuRecipe(ConanFile):
         "Tests/ControllerTest/CMakeLists.txt",\
         "Tests/ControllerTest/source/*",\
         "Tests/MachineTest/CMakeLists.txt",\
+        "Tests/MachineTest/pythonTestDeps.cmake",\
         "Tests/MachineTest/source/*",\
         "Tests/Programs/*",\
         "Tests/TestControllers/CMakeLists.txt",\
@@ -91,7 +92,9 @@ class MachEmuRecipe(ConanFile):
         tc.cache_variables["enableZlib"] = self.options.with_zlib
         tc.variables["buildArch"] = self.settings.arch
         tc.variables["archiveDir"] = self.cpp_info.libdirs[0]
-        tc.variables["runtimeDir"] = self.cpp_info.bindirs[0]
+        tc.variables["runtimeDir"] = self.cpp_info.bindirs[0]            
+        if self.settings.os == "Windows" and self.options.with_python and self.options.with_zlib and self.dependencies["zlib"].options.shared:
+            tc.variables["zlibDllDir"] = self.dependencies["zlib"].cpp_info.bindirs[0].replace("\\", "/")
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Added `pythonTestDeps.cmake` include file which gets included from both the MachineTests and the Conan package test rather than generating the python test dependencies from both projects.