### PR TITLE
#129 fix: disable running the unit tests for cross build installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Example command lines:
 3. `conan create . --build=missing --options=with_zlib=False`: same as 1 but will disable zlib support. 
 4. `conan create . --build=missing --test-folder=""`: same as 1 but will not run the basic package tests (not recommended).
 5. `conan create . --build=missing --conf=tools.build:skip_test=True`: same as 1 but will skip running the unit tests.
-6. `conan create . --build=missing --options=with_i8080_test_suites=False`: same as 1 but will not run the i8080 test suites.
+6. `conan create . --build=missing --options=with_i8080_test_suites=True`: same as 1 but will run the i8080 test suites.
 
 #### Upload a Conan package
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.build import can_run
 import os
 
 class MachEmuRecipe(ConanFile):
@@ -103,7 +104,7 @@ class MachEmuRecipe(ConanFile):
         cmake.configure()
         cmake.build()
 
-        if not self.conf.get("tools.build:skip_test", default=False):
+        if can_run(self) and not self.conf.get("tools.build:skip_test", default=False):
             testFilter = "--gtest_filter=*"
             if not self.options.with_i8080_test_suites:
                 testFilter += ":-*8080*:*CpuTest*"


### PR DESCRIPTION
- Disable running the unit tests when building for a cross compiled target.
- Minor README update.