### PR TITLE
#236 fix: reset cpu during on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
   memory["rom"] section of the machine load state format.
 * Added Machine interface method `OnIdle`.
 * Added Machine interface method `OnError`.
+* The cpu will be reset when no cpu configutation has been
+  specified by the `IMachinw::OnLoad` handler.
 
 1.6.2 [24/07/24]
 * Deprecated config options `ramOffset`, `ramSize`,

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -355,8 +355,8 @@ std::error_code Intel8080::Load(const std::string&& str, bool checkUuid)
 		status_ = registers.value<uint8_t>("s", Value(status_)) | 0x02;
 	}
 
-	programCounter_ = pc_ = json.value<uint16_t>("pc", Value(programCounter_));
-	sp_ = json.value<uint16_t>("sp", Value(sp_));
+	programCounter_ = pc_ = json.value<uint16_t>("pc", programCounter_);
+	sp_ = json.value<uint16_t>("sp", sp_);
 #else
 	JsonDocument json;
 	auto e = deserializeJson(json, str);
@@ -413,8 +413,8 @@ std::error_code Intel8080::Load(const std::string&& str, bool checkUuid)
 		status_ = (registers["s"] ? registers["s"].as<uint8_t>() : Value(status_)) | 0x02;
 	}
 
-	pc_ = json["pc"] ? json["pc"].as<uint16_t>() : Value(pc_);
-	sp_ = json["sp"] ? json["sp"].as<uint16_t>() : Value(sp_);
+	pc_ = json["pc"] ? json["pc"].as<uint16_t>() : pc_;
+	sp_ = json["sp"] ? json["sp"].as<uint16_t>() : sp_;
 #endif
 	return make_error_code(errc::no_error);
 }

--- a/source/machine/Machine.cpp
+++ b/source/machine/Machine.cpp
@@ -414,7 +414,7 @@ namespace meen
 							return m->HandleError(errc::json_config, std::source_location::current());
 						}
 
-						auto romBytes = reinterpret_cast<uint8_t*>(value);
+						auto romBytes = reinterpret_cast<const uint8_t*>(value);
 
 						// only support a max of 16 bit addressing
 						if (offset + size > 0xFFFF)
@@ -751,6 +751,10 @@ namespace meen
 					{
 						return err;
 					}
+				}
+				else
+				{
+					m->cpu_->Reset();
 				}
 			}
 


### PR DESCRIPTION
When loading the machine state, the cpu will be reset to its default when no cpu configuration is specified. When the configuration is specified, only the parameters specified will be updated, the unspecified ones will remain unchanged.