### PR TITLE
#245 fix: restore the stack pointer to a known valid value

### DIFF
--- a/include/meen/cpu/8080.h
+++ b/include/meen/cpu/8080.h
@@ -96,6 +96,9 @@ namespace meen
 		*/
 		//cppcheck-suppress unusedStructMember
 		uint16_t sp_{};
+		// The canonical stack pointer, each reset will set sp_ to this value
+		//cppcheck-suppress unusedStructMember
+		uint16_t stackPointer_{};
 
 		/**
 			Five condition (or status) bits are provided by the

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -356,7 +356,7 @@ std::error_code Intel8080::Load(const std::string&& str, bool checkUuid)
 	}
 
 	programCounter_ = pc_ = json.value<uint16_t>("pc", programCounter_);
-	sp_ = json.value<uint16_t>("sp", sp_);
+	stackPointer_ = sp_ = json.value<uint16_t>("sp", stackPointer_);
 #else
 	JsonDocument json;
 	auto e = deserializeJson(json, str);
@@ -753,7 +753,7 @@ void Intel8080::Reset()
 	h_.reset();
 	l_.reset();
 	pc_ = programCounter_;
-	sp_ = 0;
+	sp_ = stackPointer_;
 	status_ = 0b00000010;
 	iff_ = false;
 	hlt_ = false;


### PR DESCRIPTION
Every time MEEN is restarted the stack pointer will be restored to 0 (the default) or the last valid value assigned in the json cpu configuration.