### PR TITLE
#257 fix: reset cpu properties

### DIFF
--- a/include/meen/IMachine.h
+++ b/include/meen/IMachine.h
@@ -361,9 +361,18 @@ namespace meen
 			@code{.json}
 
 			{
+				// Set the cpu properties.
+				// Omitting the 'cpu' object will reset all cpu properties to zero.
 				"cpu":{
 					// Start executing the loaded program from address 256 (0x100)
-					"pc":256
+					// Omitting 'pc' will leave it unchanged.
+					"pc":256,
+					// Set the stack pointer to 0.
+					// Omitting 'sp' will leave it unchanged.
+					"sp": 0,
+					// Set the 'a' register to 42, leave the remaining registers (b, c, d, e, h, l, s) unchanged.
+					// Omitting the 'registers' object will reset all registers to zero.
+					"registers":{"a":42}
 				},
 				"memory": {
 					"rom":{
@@ -380,10 +389,6 @@ namespace meen
 			}
 
 			@endcode
-
-			NOTE: the cpu registers can also be set (see IMachine::OnSave), registers unassigned will remain unchanged.
-			NOTE: upon machine (re)start, the program counter (pc) and stack pointer (sp) will always be assigned the
-			last valid value set (or 0 if these parameters have never been set).
 
 			The memory:rom:block array can be omitted if loading from a single file:<br>
 

--- a/include/meen/cpu/8080.h
+++ b/include/meen/cpu/8080.h
@@ -85,9 +85,6 @@ namespace meen
 		*/
 		//cppcheck-suppress unusedStructMember
 		uint16_t pc_{};
-		// The canonical program counter, each reset will set pc_ to this value
-		//cppcheck-suppress unusedStructMember
-		uint16_t programCounter_{};
 
 		/**
 			A stack is an area of memory set aside by the programmer in which data or addresses are stored and retrieved
@@ -96,9 +93,6 @@ namespace meen
 		*/
 		//cppcheck-suppress unusedStructMember
 		uint16_t sp_{};
-		// The canonical stack pointer, each reset will set sp_ to this value
-		//cppcheck-suppress unusedStructMember
-		uint16_t stackPointer_{};
 
 		/**
 			Five condition (or status) bits are provided by the

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -354,9 +354,15 @@ std::error_code Intel8080::Load(const std::string&& str, bool checkUuid)
 		l_ = registers.value<uint8_t>("l", Value(l_));
 		status_ = registers.value<uint8_t>("s", Value(status_)) | 0x02;
 	}
+	// The registers object has not been specified, reset all registers to zero.
+	else
+	{
+		a_ = b_ = c_ = d_ = e_ = h_ = l_ = 0;
+		status_ = 0x02;
+	}
 
-	programCounter_ = pc_ = json.value<uint16_t>("pc", programCounter_);
-	stackPointer_ = sp_ = json.value<uint16_t>("sp", stackPointer_);
+	pc_ = json.value<uint16_t>("pc", pc_);
+	sp_ = json.value<uint16_t>("sp", sp_);
 #else
 	JsonDocument json;
 	auto e = deserializeJson(json, str);
@@ -752,8 +758,8 @@ void Intel8080::Reset()
 	e_.reset();
 	h_.reset();
 	l_.reset();
-	pc_ = programCounter_;
-	sp_ = stackPointer_;
+	pc_ = 0;
+	sp_ = 0;
 	status_ = 0b00000010;
 	iff_ = false;
 	hlt_ = false;

--- a/source/machine/Machine.cpp
+++ b/source/machine/Machine.cpp
@@ -962,7 +962,7 @@ namespace meen
 
 													if (!ec)
 													{
-														std::ofstream fout(path / fileName);
+														std::ofstream fout(path / fileName, std::ios::trunc);
 														
 														if (!fout.good())
 														{


### PR DESCRIPTION
- Reset `pc` and `sp` to 0 on cpu reset
- Leave `pc` and `sp` unchanged when they are not specified in the cpu load settings.
- Set all registers to 0 when no registers object is specified in the cpu settings. 