### PR TITLE
#263 feat: GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
       # Run the unit tests
       - name: Run unit tests
         if: github.event_name == 'pull_request'
-        run: artifacts/Release/${{ matrix.arch }}/bin/meen_test
+        run: artifacts/Release/${{ matrix.arch }}/bin/meen_test tests/programs
 
       # Build the package
       - name: Build package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,8 @@ jobs:
         if: github.ref_type == 'tag'
         uses: ssciwr/doxygen-install@v1
       - name: Install TeX Live
-        # Not building the documentation on Windows (needs to be fixed)
-        if: github.ref_type == 'tag' && runner.os == 'Linux'
+        # Only generating the documentation for Linux x86_64 (Arm Linux GitHub runner runs into an issue with Doxygen, Windows has deeper issues ...)
+        if: github.ref_type == 'tag' && runner.os == 'Linux' && matrix.arch == 'x86_64'
         run: |
           sudo apt-get install texlive-latex-base
           sudo apt-get install texlive-latex-extra

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,110 @@
+name: CI/CD
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" and "development" branches
+  push:
+    tags: [v*.*.*]
+  pull_request:
+    branches: [main, development]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # Test on each supported OS version
+  build_and_execute:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            compiler: gcc
+            cppcheck: cppcheck
+            package_dir: build/Release
+            pm: sudo apt-get
+            preset: release
+            version: 14
+          - os: ubuntu-24.04-arm
+            arch: armv8
+            compiler: gcc
+            cppcheck: cppcheck
+            package_dir: build/Release
+            pm: sudo apt-get
+            preset: release
+            version: 14
+          - os: windows-latest
+            arch: x86_64
+            compiler: msvc
+            cppcheck: C:/Program` Files/Cppcheck/cppcheck
+            package_dir: output/build
+            pm: choco
+            preset: default
+            version: 193
+
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Setup additional project requirements
+      - name: Install and setup Conan
+        uses: conan-io/setup-conan@v1
+        with: 
+          config_urls: https://github.com/nbeddows/meen.git
+          cache_packages: true
+      - name: Install Cppcheck
+        if: github.event_name == 'pull_request'
+        run: ${{ matrix.pm }} install cppcheck
+      - name: Run Cppcheck
+        if: github.event_name == 'pull_request'
+        run: ${{ matrix.cppcheck }} -ibuild -ioutput -i_CPack_Packages -itests --inline-suppr --enable=warning,style,performance,portability,unusedFunction --std=c++20 source/
+      - name: Install Doxygen
+        if: github.ref_type == 'tag'
+        uses: ssciwr/doxygen-install@v1
+      - name: Install TeX Live
+        # Not building the documentation on Windows (needs to be fixed)
+        if: github.ref_type == 'tag' && runner.os == 'Linux'
+        run: |
+          sudo apt-get install texlive-latex-base
+          sudo apt-get install texlive-latex-extra
+          sudo apt-get install texlive-font-utils
+
+      # Build the project
+      - name: Install Conan profiles
+        run: conan config install -sf profiles -tf profiles https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.2.0"
+      - name: Install dependencies
+        run: conan install . --build=missing --profile:all=${{ runner.os }}-${{ matrix.arch }}-${{ matrix.compiler }}-${{ matrix.version }}-gtest
+      - name: CMake presets
+        run: cmake --preset conan-${{ matrix.preset }}
+      - name: CMake build
+        run: cmake --build --preset conan-release
+
+      # Run the unit tests
+      - name: Run unit tests
+        if: github.event_name == 'pull_request'
+        run: artifacts/Release/${{ matrix.arch }}/bin/meen_test
+
+      # Build the package
+      - name: Build package
+        if: github.ref_type == 'tag'
+        run: cmake --build --preset conan-release --target=package
+
+      - name: Strip package
+        if: github.ref_type == 'tag' && runner.os == 'Linux'
+        run: cmake --build --preset conan-release --target=meen_strip_pkg
+
+      # Create the release
+      - name: Create release
+        if: github.ref_type == 'tag' 
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: ReleaseNotes.md
+          files: ${{ matrix.package_dir }}/meen-*.tar.gz
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2.1.0
+* Added testing and release workflows for GitHub Actions CI/CD.
+
 2.0.0 [22/06/25]
 * Updated the project layout for improved workflow.
 * Added `std::error_code` support.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,7 +548,7 @@ if(DEFINED MSVC)
   # Under Windows Doxygen documentaiton causes LaTeX to go into what looks to be an infinite loop, disable until a solution is found
   # install(CODE "execute_process(COMMAND cmd /c make WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/latex)")
 # We are not going to build the documentation on arm platforms
-elif(${build_arch} STREQUAL "x86_64")
+elseif(${build_arch} STREQUAL "x86_64")
   install(CODE "execute_process(COMMAND make WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/latex)")
 endif()
 install(TARGETS ${meen} FILE_SET HEADERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,16 +547,18 @@ install(CODE "execute_process(COMMAND doxygen ${CMAKE_SOURCE_DIR}/docs/Doxyfile)
 if(DEFINED MSVC)
   # Under Windows Doxygen documentaiton causes LaTeX to go into what looks to be an infinite loop, disable until a solution is found
   # install(CODE "execute_process(COMMAND cmd /c make WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/latex)")
-else()
+# We are not going to build the documentation on arm platforms
+elif(${build_arch} STREQUAL "x86_64")
   install(CODE "execute_process(COMMAND make WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/latex)")
 endif()
-install(CODE "execute_process(COMMAND cppcheck -ibuild -i_CPack_Packages -itests --inline-suppr --enable=warning,style,performance,portability,unusedFunction --std=c++20 ${CMAKE_SOURCE_DIR})")
 install(TARGETS ${meen} FILE_SET HEADERS)
 install(FILES ${CMAKE_SOURCE_DIR}/CHANGELOG.md DESTINATION .)
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.md RENAME LICENSE DESTINATION .)
 # Latex to PDF generation under Windows is currently not working, remove the if protection once fixed
 if(NOT DEFINED MSVC)
-  install(FILES ${CMAKE_BINARY_DIR}/latex/refman.pdf RENAME MEEN_Reference.pdf DESTINATION .)
+  if(${build_arch} STREQUAL "x86_64")
+    install(FILES ${CMAKE_BINARY_DIR}/latex/refman.pdf RENAME MEEN_Reference.pdf DESTINATION .)
+  endif()
 endif()
 
 if(NOT DEFINED WIN32)

--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ The following table displays the current defacto test suites that these unit tes
 
 ### Compilation
 
-MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build system, [Conan (minimum version 2.0)](https://conan.io/) for it's dependency package manager, Python3-dev for python module support,[cppcheck](http://cppcheck.net/) for static analysis and [Doxygen](https://www.doxygen.nl/index.html) and latex for documentation. Supported compilers are GCC (minimum version 12) and MSVC (minimum version 1706). Clang (minimum version 16) hasn't been tested for a while, therefore, it is no longer officially supported.
+MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build system, [Conan (minimum version 2.0)](https://conan.io/) for it's dependency package manager, Python3-dev for python module support, [cppcheck](http://cppcheck.net/) for static analysis, [Doxygen](https://www.doxygen.nl/index.html) for (LaTeX) PDF documentation and GitHub Actions for CI/CD. Supported compilers are GCC (minimum version 12) and MSVC (minimum version 1706).
 
 #### Pre-requisites
 
-##### Linux (Ubuntu (24.04 at time of writing))
+##### Linux (Ubuntu 25.04)
 
+- `sudo apt install gcc`
 - [Install Conan](https://conan.io/downloads/)
 - `sudo apt install cmake`
 - `sudo apt install cppcheck` (if building a binary development package)
@@ -112,6 +113,7 @@ MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build syste
 
 ##### Windows (10)
 
+- [Install Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)
 - [Install Conan](https://conan.io/downloads/)
 - [Install CMake build system](https://cmake.org/download/).
 - [Install CppCheck static analysis](http://cppcheck.net/) (if building a binary development package)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,4 @@
-## MEEN 2.1.0 Release
+## MEEN 2.1.0
 
 ## Highlights
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,5 @@
+## MEEN 2.1.0 Release
+
+## Highlights
+
+* GitHub Actions CI/CD support.


### PR DESCRIPTION
Add GitHub Actions support for CI/CD:
- Runs a release workflow when a new tag is created in the form of `v*.*.*` creating a new release and uploading binary assets for each supported platform.
- Runs an integration workflow whenever a pull request is made to the `main` or `development` branches rejecting the branch on failure.