### PR TITLE
#265 feat: drop GCC-12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,8 +92,12 @@ jobs:
         run: artifacts/Release/${{ matrix.arch }}/bin/meen_test tests/programs
       # Run Python unit tests
       - name: Run Python unit tests
-        if: github.event_name == 'pull_request'
-        run: python tests/source/meen_test/test_Machine.py -v
+        # We don't run the Python unit tests on Windows since the current Windows GitHub hosted runner has Python 3.9 and the
+        # unit tests use the 'match' keyword which was introduced in Python 3.10. Remove this runner check when the Python
+        # distro of the latest Windows runner reaches at least 3.10
+        if: github.event_name == 'pull_request' && runner.os != 'Windows'
+        # We already test the longer running test suites in the C++ tests, so we disable them for Python to improve the run time
+        run: python tests/source/meen_test/test_Machine.py -v -k MachineTest
 
       # Build the package
       - name: Build package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,16 +80,20 @@ jobs:
       - name: Install Conan profiles
         run: conan config install -sf profiles -tf profiles https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.2.0"
       - name: Install dependencies
-        run: conan install . --build=missing --profile:all=${{ runner.os }}-${{ matrix.arch }}-${{ matrix.compiler }}-${{ matrix.version }}-gtest
+        run: conan install . --build=missing --options=with_python=True --profile:all=${{ runner.os }}-${{ matrix.arch }}-${{ matrix.compiler }}-${{ matrix.version }}-gtest
       - name: CMake presets
         run: cmake --preset conan-${{ matrix.preset }}
       - name: CMake build
         run: cmake --build --preset conan-release
 
       # Run the unit tests
-      - name: Run unit tests
+      - name: Run C++ unit tests
         if: github.event_name == 'pull_request'
         run: artifacts/Release/${{ matrix.arch }}/bin/meen_test tests/programs
+      # Run Python unit tests
+      - name: Run Python unit tests
+        if: github.event_name == 'pull_request'
+        run: python tests/source/meen_test/test_Machine.py -v
 
       # Build the package
       - name: Build package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 2.1.0
 * Added testing and release workflows for GitHub Actions CI/CD.
+* Dropped GCC-12 support.
+* Added GCC-14 support.
+* The MEEN conan option --with_python is now supported on Arm Linux.
 
 2.0.0 [22/06/25]
 * Updated the project layout for improved workflow.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following table displays the current defacto test suites that these unit tes
 
 ### Compilation
 
-MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build system, [Conan (minimum version 2.0)](https://conan.io/) for it's dependency package manager, Python3-dev for python module support, [cppcheck](http://cppcheck.net/) for static analysis, [Doxygen](https://www.doxygen.nl/index.html) for (LaTeX) PDF documentation and GitHub Actions for CI/CD. Supported compilers are GCC (minimum version 12) and MSVC (minimum version 1706).
+MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build system, [Conan (minimum version 2.0)](https://conan.io/) for it's dependency package manager, Python3-dev for python module support, [cppcheck](http://cppcheck.net/) for static analysis, [Doxygen](https://www.doxygen.nl/index.html) for (LaTeX) PDF documentation and GitHub Actions for CI/CD. Supported compilers are GCC (minimum version 13) and MSVC (minimum version 1706).
 
 #### Pre-requisites
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build syste
 
 ##### Linux (Ubuntu 25.04)
 
-- `sudo apt install gcc`
+- `sudo apt install gcc g++`
 - [Install Conan](https://conan.io/downloads/)
 - `sudo apt install cmake`
 - `sudo apt install cppcheck` (if building a binary development package)
@@ -127,7 +127,7 @@ MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build syste
 
 **1.** Install the supported MEEN Conan configurations (v0.1.0) (if not done so already):
 - `conan config install -sf profiles -tf profiles `<br>
-  `https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.1.0"`
+  `https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.2.0"`
 
 **2.** The installed profiles may need to be tweaked depending on your environment.
 
@@ -146,8 +146,8 @@ MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build syste
 **NOTE**: when performing a cross compile using a host profile you must install the requisite toolchain of the target architecture (see pre-requisites).<br>
 
 The following additional install options are supported:
-- enable/disable python module support: `--options=with_python=[True|False(default)]` (Option not available on arm platforms)
-- enable/disable zlib support: `--options=with_zlib=[True(default)|False]` (Options not available on embedded platofrms)
+- enable/disable python module support: `--options=with_python=[True|False(default)]` (Option not available on embedded platforms)
+- enable/disable zlib support: `--options=with_zlib=[True(default)|False]` (Option not available on embedded platofrms)
 
 The following will enable python and disable zlib: `conan install . --build=missing --profile:all=Windows-x86_64-msvc-193 --options=with_python=True --options=with_zlib=False`
 
@@ -174,7 +174,7 @@ A Debug preset (or MinRelSize or RelWithDebugInfo) can be used if the said build
 
 **NOTE**: the options supported during the install step can also be enabled/disabled here if required:
 - Disable zlib support: `cmake --preset conan-default -D enable_zlib=OFF`
-- Enable the Python module: `cmake --preset conan-default -D enable_python_module=ON` (Unsupported on arm, CMake will fail)
+- Enable the Python module: `cmake --preset conan-default -D enable_python_module=ON`
 
 **5.** Run cmake to compile MEEN: `cmake --build --preset conan-release`<br>
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -93,9 +93,7 @@ class MeenRecipe(ConanFile):
             self.output.info("base64 uri scheme and saving are not supported, removing options with_base64 and with_save")
             self.options.rm_safe("with_save")
             self.options.rm_safe("with_base64")
-
-        if "arm" in self.settings.arch:
-            self.output.info("Python ARM module not supported, removing option with_python.")
+            self.output.info("Python module not supported, removing option with_python.")
             self.options.rm_safe("with_python")
 
         if self.settings_build.os == "Windows":

--- a/include/meen/opt/Opt.h
+++ b/include/meen/opt/Opt.h
@@ -55,6 +55,10 @@ namespace meen
 #else
 			JsonDocument json_{};
 
+			mutable std::string encoder_;
+
+			mutable std::string compressor_;
+
 			static void Merge(JsonVariant dst, JsonVariantConst src);
 #endif
 			/**
@@ -66,7 +70,7 @@ namespace meen
 
 			/*
 				Parse a json string view
-				
+
 				Helper methods to parse json strings.
 			*/
 #ifdef ENABLE_NLOHMANN_JSON
@@ -114,13 +118,13 @@ namespace meen
 
 				Supported compressors, currently only zlib is supported.
 			*/
-			std::string Compressor() const;
+			const std::string& Compressor() const;
 
 			/** Text to binary encoder
 
 				Supported encoders, currently only base64 is supported.
 			*/
-			std::string Encoder() const;
+			const std::string& Encoder() const;
 
 			/** Machine state load mode
 

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -431,14 +431,23 @@ std::error_code Intel8080::Load(const std::string&& str, bool checkUuid)
 std::expected<std::string, std::error_code> Intel8080::Save() const
 {
 	auto b64 = Utils::BinToTxt("base64", "none", uuid_.data(), uuid_.size());
-	
+
 	if (!b64)
 	{
 		return b64;
 	}
 
+	auto a = Value(a_);
+	auto b = Value(b_);
+	auto c = Value(c_);
+	auto d = Value(d_);
+	auto e = Value(e_);
+	auto h = Value(h_);
+	auto l = Value(l_);
+	auto s = Value(status_);
+
 	return std::vformat(R"({{"uuid":"base64://{}","registers":{{"a":{},"b":{},"c":{},"d":{},"e":{},"h":{},"l":{},"s":{}}},"pc":{},"sp":{}}})",
-						std::make_format_args(b64.value().c_str(), Value(a_), Value(b_), Value(c_), Value(d_), Value(e_), Value(h_), Value(l_), Value(status_), pc_, sp_));
+						std::make_format_args(b64.value(), a, b, c, d, e, h, l, s, pc_, sp_));
 }
 #endif // ENABLE_MEEN_SAVE
 

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -21,14 +21,16 @@ SOFTWARE.
 */
 
 #include <assert.h>
+#include <format>
 #ifdef ENABLE_NLOHMANN_JSON
 #include <nlohmann/json.hpp>
 #else
 #define ARDUINOJSON_ENABLE_STRING_VIEW 1
 #include <ArduinoJson.h>
 #endif // ENABLE_NLOHMANN_JSON
-#include "meen/utils/Utils.h"
+
 #include "meen/cpu/8080.h"
+#include "meen/utils/Utils.h"
 #include "meen/utils/ErrorCode.h"
 
 namespace meen
@@ -435,11 +437,8 @@ std::expected<std::string, std::error_code> Intel8080::Save() const
 		return b64;
 	}
 
-	auto fmtStr = R"({"uuid":"base64://%s","registers":{"a":%d,"b":%d,"c":%d,"d":%d,"e":%d,"h":%d,"l":%d,"s":%d},"pc":%d,"sp":%d})";
-	auto count = snprintf(nullptr, 0, fmtStr, b64.value().c_str(), Value(a_), Value(b_), Value(c_), Value(d_), Value(e_), Value(h_), Value(l_), Value(status_), pc_, sp_);
-	std::string str(count + 1, '\0');
-	snprintf(str.data(), count + 1, fmtStr, b64.value().c_str(), Value(a_), Value(b_), Value(c_), Value(d_), Value(e_), Value(h_), Value(l_), Value(status_), pc_, sp_);
-	return str;
+	return std::vformat(R"({{"uuid":"base64://{}","registers":{{"a":{},"b":{},"c":{},"d":{},"e":{},"h":{},"l":{},"s":{}}},"pc":{},"sp":{}}})",
+						std::make_format_args(b64.value().c_str(), Value(a_), Value(b_), Value(c_), Value(d_), Value(e_), Value(h_), Value(l_), Value(status_), pc_, sp_));
 }
 #endif // ENABLE_MEEN_SAVE
 

--- a/source/machine_py/MachineModule.cpp
+++ b/source/machine_py/MachineModule.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <format>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -85,7 +86,8 @@ PYBIND11_MODULE(meenPy, meen)
                         return meen::errc::invalid_argument;
                     }
 
-                    *jsonLen = snprintf(json, *jsonLen, "%s", loadState.c_str());
+                    std::vformat_to(json, "{}", std::make_format_args(loadState));
+                    *jsonLen = loadState.size();
                     return meen::errc::no_error;
                 }, [olc = std::move(onLoadComplete)](meen::IController* ioController)
                 {
@@ -110,7 +112,8 @@ PYBIND11_MODULE(meenPy, meen)
                         return meen::errc::invalid_argument;
                     }
 
-                    *uriLen = snprintf(uri, *uriLen, "%s", location.c_str());
+                    std::vformat_to(uri, "{}", std::make_format_args(location));
+                    *uriLen = location.size();
                     return meen::errc::no_error;
                 }, [os = std::move(onSave)](const char* location, const char* json, meen::IController* ioController)
                 {

--- a/source/opt/Opt.cpp
+++ b/source/opt/Opt.cpp
@@ -226,21 +226,23 @@ namespace meen
 #endif // ENABLE_NLOHMANN_JSON
 	}
 
-	std::string Opt::Compressor() const
+	const std::string& Opt::Compressor() const
 	{
 #ifdef ENABLE_NLOHMANN_JSON
-		return json_["compressor"].get<std::string>();
+		return json_["compressor"].get_ref<const std::string&>();
 #else
-		return json_["compressor"].as<std::string>();
+		compressor_ = json_["compressor"].as<std::string>();
+		return compressor_;
 #endif // ENABLE_NLOHMANN_JSON
 	}
 
-	std::string Opt::Encoder() const
+	const std::string& Opt::Encoder() const
 	{
 #ifdef ENABLE_NLOHMANN_JSON
-		return json_["encoder"].get<std::string>();
+		return json_["encoder"].get_ref<const std::string&>();
 #else
-		return json_["encoder"].as<std::string>();
+		encoder_ = json_["encoder"].as<std::string>();
+		return encoder_;
 #endif // ENABLE_NLOHMANN_JSON
 	}
 

--- a/tests/source/meen_test/MeenGTest.cpp
+++ b/tests/source/meen_test/MeenGTest.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <format>
 #include <gtest/gtest.h>
 #include <memory>
 #ifdef ENABLE_NLOHMANN_JSON
@@ -36,6 +37,8 @@ SOFTWARE.
 #include "test_controllers/MemoryController.h"
 #include "test_controllers/TestIoController.h"
 #include "test_controllers/CpmIoController.h"
+
+using namespace std::literals::string_view_literals;
 
 namespace meen::Tests
 {
@@ -57,7 +60,8 @@ namespace meen::Tests
 		static void Run(bool runAsync);
 		static void Load(bool runAsync);
 		static void RunTestSuite(const char* suiteName, const char* expectedState, const char* expectedMsg, size_t pos);
-		static errc LoadProgram (char* json, int* jsonLen, const char* fmt, ...);
+		template <typename... Args>
+		static errc LoadProgram(char* json, int* jsonLen, const std::format_string<Args...> fmt, Args&&... args);
 		static std::string ReadCpmIoControllerBuffer();
 
 	public:
@@ -123,22 +127,21 @@ namespace meen::Tests
 		EXPECT_FALSE(err);
 	}
 
-	errc MachineTest::LoadProgram(char* json, int* jsonLen, const char* fmt, ...)
+	template<class... Args>
+	errc MachineTest::LoadProgram(char* json, int* jsonLen, const std::format_string<Args...> fmt, Args&&... args)
 	{
-		va_list args;
-		va_start(args, fmt);
-
-		auto len = vsnprintf(json, *jsonLen, fmt, args);
+		auto formattedSize = std::formatted_size(fmt, args...);
 
 		// A write error occurred while executing the function, odds are that one of our parameters are incorrect.
-		// When len == *jsonLen, the config option `maxLoadStateLen` needs to be increased
-		if (len < 0 || len == *jsonLen)
+		// When len > *jsonLen, the config option `maxLoadStateLen` needs to be increased
+		if (formattedSize <= 0 || formattedSize > *jsonLen)
 		{
 			return errc::invalid_argument;
 		}
 
+		std::vformat_to(json, fmt.get(), std::make_format_args(args...));
 		// Write the final length of the loaded program
-		*jsonLen = len;
+		*jsonLen = formattedSize;
 		return errc::no_error;
 	}
 
@@ -164,7 +167,7 @@ namespace meen::Tests
 		err = machine_->OnSave([&saveTriggered, expected](char* uri, int* uriLen, [[maybe_unused]] IController* ioController)
 		{
 			// Return back a protocol that is unsupported so that our completion handler is called
-			*uriLen = snprintf(uri, *uriLen, "%s", "json://gtest");
+			*uriLen = std::format_to_n(uri, *uriLen, "json://gtest").size;
 			return meen::errc::no_error;
 		}, [&saveTriggered, expected](const char* location, const char* actual, [[maybe_unused]] IController* ioController)
 		{
@@ -198,11 +201,11 @@ namespace meen::Tests
 		{
 			if (extra == nullptr)
 			{
-				return LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":256}]}}})", saveAndExit, name);
+				return LoadProgram(json, jsonLen, R"(json://{{"cpu":{{"pc":256}},"memory":{{"rom":{{"block":[{{"bytes":"{}","offset":0}},{{"bytes":"{}","offset":256}}]}}}}}})"sv, saveAndExit, name);
 			}
 			else
 			{
-				return LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":256},{"bytes":"%s","offset":%d}]}}})", saveAndExit, name, extra, offset);
+				return LoadProgram(json, jsonLen, R"(json://{{"cpu":{{"pc":256}},"memory":{{"rom":{{"block":[{{"bytes":"{}","offset":0}},{{"bytes":"{}","offset":256}},{{"bytes":"{}","offset":{}}}]}}}}}})"sv, saveAndExit, name, extra, offset);
 			}
 		}, nullptr);
 
@@ -344,7 +347,7 @@ namespace meen::Tests
 
 		machine_->OnLoad([](char* json, int* jsonLen, [[maybe_unused]] IController* ioController)
 		{
-			return LoadProgram (json, jsonLen, R"(json://{"cpu":{"pc":5},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":5},{"bytes":"%s","offset":50004}]}}})", saveAndExit, nopStart, nopEnd);
+			return LoadProgram (json, jsonLen, R"(json://{{"cpu":{{"pc":5}},"memory":{{"rom":{{"block":[{{"bytes":"{}","offset":0}},{{"bytes":"{}","offset":5}},{{"bytes":"{}","offset":50004}}]}}}}}})"sv, saveAndExit, nopStart, nopEnd);
 		}, nullptr);
 
 		if (runAsync == true)
@@ -412,7 +415,7 @@ namespace meen::Tests
 			err = machine_->OnSave([&](char* uri, int* uriLen, [[maybe_unused]] IController* ioController)
 			{
 				// Return back a protocol that is unsupported so that our completion handler is called
-				*uriLen = snprintf(uri, *uriLen, "%s", "json://gtest");
+				*urlLen = std::format_to_n(uri, *uriLen, "json://gtest").size;
 				return meen::errc::no_error;
 			}, [&](const char* location, const char* json, [[maybe_unused]] IController* ioController)
 			{
@@ -437,7 +440,7 @@ namespace meen::Tests
 					// be subtracted from the total size of the file,
 					// hence an explicit setting of the test file size.
 					case 0:
-						err = LoadProgram(json, jsonLen, R"(json://{"cpu":{"pc":256},"memory":{"rom":{"block":[{"bytes":"%s","offset":0},{"bytes":"%s","offset":5},{"bytes":"file://%s/TST8080.COM","offset":256,"size":1471}]}}})", saveAndExit, bdosMsg, progDir);
+						err = LoadProgram(json, jsonLen, R"(json://{{"cpu":{{"pc":256}},"memory":{{"rom":{{"block":[{{"bytes":"{}","offset":0}},{{"bytes":"{}","offset":5}},{{"bytes":"file://{}/TST8080.COM","offset":256,"size":1471}}]}}}}}})"sv, saveAndExit, bdosMsg, progDir);
 						break;
 					case 1:
 						EXPECT_FALSE(saveStates.empty());
@@ -445,7 +448,19 @@ namespace meen::Tests
 						if (saveStates.empty() == false)
 						{
 							// 0 - mid program save state, 1 and 2 - end of program save states
-							err = LoadProgram(json, jsonLen, (std::string("json://") + saveStates[0]).c_str());
+							auto str = std::string("json://") + saveStates[0];
+
+							// When len > *jsonLen, the config option `maxLoadStateLen` needs to be increased
+							if (str.length() > *jsonLen)
+							{
+								err = errc::invalid_argument;
+							}
+							else
+							{
+								strncpy(json, str.c_str(), str.length());
+								// Write the final length of the loaded program
+								*jsonLen = str.length();
+							}
 						}
 						break;
 					default:

--- a/tests/source/meen_test/MeenGTest.cpp
+++ b/tests/source/meen_test/MeenGTest.cpp
@@ -415,7 +415,7 @@ namespace meen::Tests
 			err = machine_->OnSave([&](char* uri, int* uriLen, [[maybe_unused]] IController* ioController)
 			{
 				// Return back a protocol that is unsupported so that our completion handler is called
-				*urlLen = std::format_to_n(uri, *uriLen, "json://gtest").size;
+				*uriLen = std::format_to_n(uri, *uriLen, "json://gtest").size;
 				return meen::errc::no_error;
 			}, [&](const char* location, const char* json, [[maybe_unused]] IController* ioController)
 			{


### PR DESCRIPTION
- Run the Python unit tests for CI builds (Non-Windows due to runners Python version).
- Enable Python under Arm (the option `with_python` can be true).
- Use std::format over sprintf where possible.
- Update README for gcc-14 support.