### PR TITLE
#273 feat: `with_framework` Conan option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
 
       # Build the project
       - name: Install Conan profiles
-        run: conan config install -sf profiles -tf profiles https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.2.0"
+        run: conan config install -sf profiles -tf profiles https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.3.0"
       - name: Install dependencies
         run: conan install . --build=missing --options=with_python=True --profile:all=${{ runner.os }}-${{ matrix.arch }}-${{ matrix.compiler }}-${{ matrix.version }}-gtest
       - name: CMake presets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   Pico SDK version 2.0.0.
 * Embed common information in meen_test.uf2.
 * Replaced Conan option `with_rp2040` with `with_board`.
+* Added the Conan option `with_framework`.
+* Now using ArduinoJson exclusively.
 
 2.0.0 [22/06/25]
 * Updated the project layout for improved workflow.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,23 +455,26 @@ if(NOT BUILD_TESTING STREQUAL OFF)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/tests/programs DESTINATION tests)
 ##### Generate unit test run script
     if(DEFINED MSVC)
-      # write out a script which exports the runtime directory and runs the tests, $@ - bash all command line arguemnts
+      # write out a script which exports the runtime directory and runs the tests, $@ - bash all command line arguments
       if(${enable_python_module} STREQUAL ON)
         set(pythonFilter "set python-filter=-k *")
         set(pythonCmdLine "IF \"%~1\"==\"--python_filter\" set python-filter=-k %~2")
         set(pythonExecute "echo Running Python unit tests\npython tests\\test_Machine.py -v %python-filter%")
       endif()
 
-#### TODO: Need to add Unity support when ${enable_framework} == "unity"
+      if(${enable_framework} STREQUAL "gtest")
+        set(gTestFilter "set gtest-filter=--gtest_filter=*")
+        set(gtestCmdLine "IF \"%~1\"==\"--gtest_filter\" set gtest-filter=%~1=%~2")
+      endif()
 
       # start run-meen-unit-tests.bat --gtest_filter=*LXI_B* --python_filter=Tst8080
       file(WRITE ${CMAKE_BINARY_DIR}/run-${meen}-unit-tests.bat
           "@echo off\n\
-set gtest-filter=--gtest_filter=*\n\
+${gtestFilter}
 ${pythonFilter}
 :parse\n\
 IF \"%~1\"==\"\" GOTO endparse\n\
-IF \"%~1\"==\"--gtest_filter\" set gtest-filter=%~1=%~2\n\
+${gtestCmdLine}\n\
 ${pythonCmdLine}\n\
 SHIFT\n\
 GOTO parse\n\
@@ -493,22 +496,22 @@ exit"
         set(pythonExecute "echo Running Python unit tests\npython tests/test_Machine.py -v \${python_filter}")
       endif()
 
-#### TODO: Need to add Unity support when ${enable_framework} == "unity"
+      if(${enable_framework} STREQUAL "gtest")
+        set(gtestFilter "export gtest_filter=\"--gtest_filter=*\"")
+        set(gtestCmdLine "--gtest_filter)\nexport gtest_filter=\"$1=$2\"\nshift\n;;")
+      endif()
 
       file(WRITE ${CMAKE_BINARY_DIR}/run-${meen}-unit-tests.sh
 "#!/bin/bash\n\
-export gtest_filter=\"--gtest_filter=*\"\n\
+${gtestFilter}\n\
 ${pythonFilter}\n\
 while [[ \$# -gt 0 ]]; do\n\
   case \$1 in\n\
-    --gtest_filter)\n\
-      export gtest_filter=\"\$1=\$2\"\n\
-      shift\n\
-    ;;\n\
+    ${gtestCmdLine}\n\
     ${pythonCmdLine}\n\
     *)\n\
       echo Invalid option: \$1\n\
-      echo ./run-${meen}-unit-tests [--gtest_filter \\\$gtest_filter][--python_filter \\\${python_filter}
+      echo ./run-${meen}-unit-tests [--gtest_filter \\\${gtest_filter}][--python_filter \\\${python_filter}]
       exit\n\
       ;;\n\
   esac\n\
@@ -517,7 +520,7 @@ done\n\
 echo Adding `pwd`/${archive_dir} to LD_LIBRARY_PATH\n\
 export LD_LIBRARY_PATH=`pwd`/${archive_dir}:\${LD_LIBRARY_PATH}\n\
 echo Running C++ unit tests\n\
-${runtime_dir}/${meen}_test \"\${gtest_filter}\" tests/programs/\n\
+${runtime_dir}/${meen}_test \${gtest_filter} tests/programs/\n\
 ${pythonExecute}"
       )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ endif()
 
 # Stage 2: locate our required packages
 
+find_package(ArduinoJson REQUIRED)
+
 if(${enable_python_module} STREQUAL ON)
   find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
   find_package(pybind11 REQUIRED)
@@ -110,16 +112,12 @@ if(${enable_hash_library} STREQUAL ON)
   find_package(hash-library REQUIRED)
 endif()
 
-if(${build_os} STREQUAL "baremetal")
-  find_package(ArduinoJson REQUIRED)
-
-  if(NOT BUILD_TESTING STREQUAL OFF)
+if(NOT BUILD_TESTING STREQUAL OFF)
+  if(${enable_framework} STREQUAL unity)
     find_package(Unity REQUIRED)
   endif()
-else()
-  find_package(nlohmann_json REQUIRED)
 
-  if(NOT BUILD_TESTING STREQUAL OFF)
+  if(${enable_framework} STREQUAL gtest)
     find_package(GTest REQUIRED)
   endif()
 endif()
@@ -263,22 +261,19 @@ target_compile_definitions(${meen} PRIVATE ${meen}_VERSION=\"${CMAKE_PROJECT_VER
 target_compile_definitions(${meen} PUBLIC ${meen}_${lib_type})
 target_include_directories(${meen} PRIVATE ${include_dir})
 
-if(${build_os} STREQUAL "baremetal")
-  if(NOT ${enable_board} STREQUAL "none")
+target_link_libraries(${meen} PUBLIC ArduinoJson)
+
+if(${build_os} STREQUAL baremetal)
+  if(NOT ${enable_board} STREQUAL none)
     target_link_libraries(${meen} PRIVATE pico_stdlib)
     target_link_libraries(${meen} PRIVATE pico_multicore)
   endif()
-
-  target_link_libraries(${meen} PUBLIC ArduinoJson)
 
   if(DEFINED MSVC)
     message("todo: disable exceptions and rtti for msvc")
   else()
     target_compile_options(${meen} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions -fno-rtti>)
   endif()
-else()
-  target_compile_definitions(${meen} PUBLIC ENABLE_NLOHMANN_JSON)
-  target_link_libraries(${meen} PUBLIC nlohmann_json::nlohmann_json)
 endif()
 
 if(${enable_base64} STREQUAL ON)
@@ -338,8 +333,8 @@ if(NOT BUILD_TESTING STREQUAL OFF)
     tests/${source_dir}/${test_controllers}/TestIoController.cpp
   )
 
-  if(${build_os} STREQUAL "baremetal")
-    if(NOT ${enable_board} STREQUAL "none")
+  if(${build_os} STREQUAL baremetal)
+    if(NOT ${enable_board} STREQUAL none)
       set(${test_controllers}_source_files
         ${${test_controllers}_source_files}
         tests/${source_dir}/${test_controllers}/TestPrograms.S
@@ -384,11 +379,12 @@ if(NOT BUILD_TESTING STREQUAL OFF)
   endif()
 
 ##### MEEN TEST
-
-  if(${build_os} STREQUAL "baremetal")
+  if(${enable_framework} STREQUAL unity)
     set(${meen}_test_source_files tests/${source_dir}/${meen}_test/MeenUnityTest.cpp)
     set(${meen}_test_deps unity::unity)
-  else()
+  endif()
+
+  if(${enable_framework} STREQUAL gtest)
     set(${meen}_test_source_files tests/${source_dir}/${meen}_test/MeenGTest.cpp)
     set(${meen}_test_deps GTest::GTest)
   endif()
@@ -397,8 +393,8 @@ if(NOT BUILD_TESTING STREQUAL OFF)
 
   add_executable(${meen}_test ${${meen}_test_source_files})
 
-  if(${build_os} STREQUAL "baremetal")
-    if(NOT ${enable_board} STREQUAL "none")
+  if(${build_os} STREQUAL baremetal)
+    if(NOT ${enable_board} STREQUAL none)
       # PICO_USE_FASTEST_SUPPORTED_CLOCK is only available in SDK Version 2.x.x
       if(${PICO_SDK_VERSION_MAJOR} GREATER_EQUAL 2)
         target_compile_definitions(${meen}_test PRIVATE PICO_USE_FASTEST_SUPPORTED_CLOCK=1)
@@ -413,11 +409,11 @@ if(NOT BUILD_TESTING STREQUAL OFF)
       # pico_set_program_version_string(${meen}_test "${major}.${minor}.${bugfix}")
       pico_set_program_url(${meen}_test "https://github.com/nbeddows/meen")
       pico_add_extra_outputs(${meen}_test)
-      install(PROGRAMS ${CMAKE_BINARY_DIR}/${meen}_test.bin DESTINATION ./bin)
-      install(FILES ${CMAKE_BINARY_DIR}/${meen}_test.uf2 DESTINATION ./bin)
-      install(FILES ${CMAKE_BINARY_DIR}/${meen}_test.dis DESTINATION ./lib)
-      install(FILES ${CMAKE_BINARY_DIR}/${meen}_test.map DESTINATION ./lib)
-      install(FILES ${CMAKE_BINARY_DIR}/${meen}_test.hex DESTINATION ./lib)
+      install(PROGRAMS ${CMAKE_BINARY_DIR}/${meen}_test.bin DESTINATION bin)
+      install(FILES ${CMAKE_BINARY_DIR}/${meen}_test.uf2 DESTINATION bin)
+      install(FILES ${CMAKE_BINARY_DIR}/${meen}_test.dis DESTINATION lib)
+      install(FILES ${CMAKE_BINARY_DIR}/${meen}_test.map DESTINATION lib)
+      install(FILES ${CMAKE_BINARY_DIR}/${meen}_test.hex DESTINATION lib)
     endif()
   endif()
 
@@ -450,7 +446,7 @@ if(NOT BUILD_TESTING STREQUAL OFF)
 
   install(TARGETS ${meen}_test RUNTIME DESTINATION ${runtime_dir})
 
-  if(${build_os} STREQUAL "baremetal")
+  if(${build_os} STREQUAL baremetal)
     install(FILES ${CMAKE_SOURCE_DIR}/tests/programs/8080EXM.COM DESTINATION tests/programs)
     install(FILES ${CMAKE_SOURCE_DIR}/tests/programs/8080PRE.COM DESTINATION tests/programs)
     install(FILES ${CMAKE_SOURCE_DIR}/tests/programs/CPUTEST.COM DESTINATION tests/programs)
@@ -465,6 +461,8 @@ if(NOT BUILD_TESTING STREQUAL OFF)
         set(pythonCmdLine "IF \"%~1\"==\"--python_filter\" set python-filter=-k %~2")
         set(pythonExecute "echo Running Python unit tests\npython tests\\test_Machine.py -v %python-filter%")
       endif()
+
+#### TODO: Need to add Unity support when ${enable_framework} == "unity"
 
       # start run-meen-unit-tests.bat --gtest_filter=*LXI_B* --python_filter=Tst8080
       file(WRITE ${CMAKE_BINARY_DIR}/run-${meen}-unit-tests.bat
@@ -494,6 +492,8 @@ exit"
         set(pythonCmdLine "--python_filter)\nexport python_filter=\"-k$2\"\nshift\n;;")
         set(pythonExecute "echo Running Python unit tests\npython tests/test_Machine.py -v \${python_filter}")
       endif()
+
+#### TODO: Need to add Unity support when ${enable_framework} == "unity"
 
       file(WRITE ${CMAKE_BINARY_DIR}/run-${meen}-unit-tests.sh
 "#!/bin/bash\n\
@@ -549,7 +549,7 @@ if(DEFINED MSVC)
   # Under Windows Doxygen documentaiton causes LaTeX to go into what looks to be an infinite loop, disable until a solution is found
   # install(CODE "execute_process(COMMAND cmd /c make WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/latex)")
 # We are not going to build the documentation on arm platforms
-elseif(${build_arch} STREQUAL "x86_64")
+elseif(${build_arch} STREQUAL x86_64)
   install(CODE "execute_process(COMMAND make WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/latex)")
 endif()
 install(TARGETS ${meen} FILE_SET HEADERS)
@@ -557,7 +557,7 @@ install(FILES ${CMAKE_SOURCE_DIR}/CHANGELOG.md DESTINATION .)
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.md RENAME LICENSE DESTINATION .)
 # Latex to PDF generation under Windows is currently not working, remove the if protection once fixed
 if(NOT DEFINED MSVC)
-  if(${build_arch} STREQUAL "x86_64")
+  if(${build_arch} STREQUAL x86_64)
     install(FILES ${CMAKE_BINARY_DIR}/latex/refman.pdf RENAME MEEN_Reference.pdf DESTINATION .)
   endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ MEEN uses [CMake (minimum version 3.23)](https://cmake.org/) for its build syste
 
 **1.** Install the latest supported MEEN Conan configuration profiles (if not done so already):
 - `conan config install -sf profiles -tf profiles `<br>
-  `https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.2.1"`
+  `https://github.com/nbeddows/meen-conan-config.git --args "--branch v0.3.0"`
 
 **2.** The installed profiles may need to be tweaked depending on your environment.
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This example will assume you are deploying the UF2 file from a Raspberry Pi.
 **Python**:
 - `tests\source\meen_test\test_Machine.py -v [-k ${python_filter}]`
 
-**Note**: for the C++ unit tests the command line option --gtest_filter can be used to run a subset of the tests and under Python the -k option can be used for the same effect.
+**NOTE**: for the C++ unit tests the command line option --gtest_filter (for gtest based profiles only) can be used to run a subset of the tests and under Python the -k option can be used for the same effect.
 - `artifacts\Release\x86_64\bin\meen_test --gtest_filter=*:-*8080*:*CpuTest*`: run all tests except the i8080 test suites.
 - `tests\source\meen_test\test_Machine.py -v -k MachineTest`: run all tests except the i8080 test suites.
 
@@ -256,6 +256,7 @@ When the package has been built with unit tests enabled it will contain a script
 - `start run-meen-unit-tests.bat [--gtest_filter ${gtest_filter}] [--python_filter ${python_filter}]`
 
 **NOTE**: the package will not contain Python units tests if MEEN was not configured with the python module enabled.
+**NOTE**: the meen-unit-tests script does not support filters for unity based profiles.
 
 #### Export a Conan package
 

--- a/source/machine/Machine.cpp
+++ b/source/machine/Machine.cpp
@@ -177,8 +177,8 @@ namespace meen
 						
 						if (fread(jsonStr.data(), jsonStr.size(), 1, fin) != 1)
 						{
-							return m->HandleError(errc::incompatible_rom, std::source_location::current());
 							fclose(fin);
+							return m->HandleError(errc::incompatible_rom, std::source_location::current());
 						}
 
 						fclose(fin);


### PR DESCRIPTION
- Change the Conan option `with_rp2040` to `with_board` to allow for specific pico board variants to be targeted.
- Added the Conan option `with_framework` to allow for different unit testing frameworks to be targeted.
- Requires MEEN Conan Config v0.3.0 to be installed (otherwise these options will need to be specified as option arguments to Conan).