### PR TITLE
#274 style: meen python name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Replaced Conan option `with_rp2040` with `with_board`.
 * Added the Conan option `with_framework`.
 * Now using ArduinoJson exclusively.
+* MEEN pybind library names now use snake_case instead of
+  CamelCase.
 
 2.0.0 [22/06/25]
 * Updated the project layout for improved workflow.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,13 +297,13 @@ if(${enable_zlib} STREQUAL ON)
 endif()
 
 if(${enable_python_module} STREQUAL ON)
-  pybind11_add_module(${meen}Py
+  pybind11_add_module(${meen}_py
     ${${meen}_py_include_files}
     ${${meen}_py_source_files}
   )
-  target_link_directories(${meen}Py PRIVATE ${Python_LIBRARY_DIRS})
-  target_link_libraries(${meen}Py PRIVATE pybind11::headers ${meen})
-  install(TARGETS ${meen}Py DESTINATION ${runtime_dir})
+  target_link_directories(${meen}_py PRIVATE ${Python_LIBRARY_DIRS})
+  target_link_libraries(${meen}_py PRIVATE pybind11::headers ${meen})
+  install(TARGETS ${meen}_py DESTINATION ${runtime_dir})
 endif()
 
 if(DEFINED zlib_bin_dir)
@@ -364,14 +364,13 @@ if(NOT BUILD_TESTING STREQUAL OFF)
     set (${test_controllers_py}_source_files tests/${source_dir}/${test_controllers_py}/TestControllersPy.cpp)
     SOURCE_GROUP(${source_dir} FILES ${${test_controllers_py}_source_files})
 
-    # todo: replace with TestControllersPy with ${test_controllers_py} when moving to meen 2.0
-    pybind11_add_module(TestControllersPy ${${test_controllers_py}_source_files})
+    pybind11_add_module(${test_controllers_py} ${${test_controllers_py}_source_files})
 
-    set_target_properties(TestControllersPy PROPERTIES FOLDER tests)
-    target_include_directories(TestControllersPy PRIVATE ${include_dir} tests/${include_dir})
-    target_link_directories(TestControllersPy PRIVATE ${Python_LIBRARY_DIRS})
-    target_link_libraries(TestControllersPy PRIVATE pybind11::headers ${test_controllers})
-    install(TARGETS TestControllersPy LIBRARY DESTINATION ${runtime_dir})
+    set_target_properties(${test_controllers_py} PROPERTIES FOLDER tests)
+    target_include_directories(${test_controllers_py} PRIVATE ${include_dir} tests/${include_dir})
+    target_link_directories(${test_controllers_py} PRIVATE ${Python_LIBRARY_DIRS})
+    target_link_libraries(${test_controllers_py} PRIVATE pybind11::headers ${test_controllers})
+    install(TARGETS ${test_controllers_py} LIBRARY DESTINATION ${runtime_dir})
     install(FILES ${CMAKE_SOURCE_DIR}/tests/source/test_controllers/BaseIoController.py DESTINATION tests)
     install(FILES ${CMAKE_SOURCE_DIR}/tests/source/test_controllers/CpmIoController.py DESTINATION tests)
     install(FILES ${CMAKE_SOURCE_DIR}/tests/source/test_controllers/MemoryController.py DESTINATION tests)

--- a/source/machine_py/MachineModule.cpp
+++ b/source/machine_py/MachineModule.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 namespace py = pybind11;
 
 //cppcheck-suppress unusedFunction
-PYBIND11_MODULE(meenPy, meen)
+PYBIND11_MODULE(meen_py, meen)
 {
     meen.attr("__version__") = meen::Version();
 

--- a/tests/conan_package_test/source/MeenPackageTest.py
+++ b/tests/conan_package_test/source/MeenPackageTest.py
@@ -22,6 +22,6 @@ import MachineTestDeps
 import os
 import sys
 
-from meenPy import __version__
+from meen_py import __version__
 print("meen python module version:", __version__)
 

--- a/tests/source/meen_test/test_Machine.py
+++ b/tests/source/meen_test/test_Machine.py
@@ -24,9 +24,9 @@ import re
 import sys
 import unittest
 
-from meenPy import __version__
-from meenPy import ErrorCode
-from meenPy import Make8080Machine
+from meen_py import __version__
+from meen_py import ErrorCode
+from meen_py import Make8080Machine
 
 # Import Python controller modules (a port of the c++ modules are available below)
 # Always use the c++ memory controller module for performance reasons, the python module is available strictly for demonstration purposes
@@ -36,9 +36,9 @@ from CpmIoController import CpmIoController
 
 # These c++ controller module versions are also available
 # Always use the c++ memory controller for performance reasons
-from TestControllersPy import MemoryController
-#from TestControllersPy import CpmIoController
-#from TestControllersPy import TestIoController
+from test_controllers_py import MemoryController
+#from test_controllers_py import CpmIoController
+#from test_controllers_py import TestIoController
 
 class MachineTest(unittest.TestCase):
     def setUp(self):

--- a/tests/source/test_controllers/BaseIoController.py
+++ b/tests/source/test_controllers/BaseIoController.py
@@ -1,5 +1,5 @@
-from meenPy import Controller
-from meenPy import ISR
+from meen_py import Controller
+from meen_py import ISR
 
 class BaseIoController(Controller):
     def __init__(self):

--- a/tests/source/test_controllers/CpmIoController.py
+++ b/tests/source/test_controllers/CpmIoController.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 from BaseIoController import BaseIoController
-from meenPy import ISR
+from meen_py import ISR
 
 class CpmIoController(BaseIoController):
     def __init__(self):

--- a/tests/source/test_controllers/MemoryController.py
+++ b/tests/source/test_controllers/MemoryController.py
@@ -1,5 +1,5 @@
-from meenPy import Controller
-from meenPy import ISR
+from meen_py import Controller
+from meen_py import ISR
 import numpy as np
 
 class MemoryController(Controller):

--- a/tests/source/test_controllers/TestIoController.py
+++ b/tests/source/test_controllers/TestIoController.py
@@ -1,5 +1,5 @@
 from BaseIoController import BaseIoController
-from meenPy import ISR
+from meen_py import ISR
 
 class TestIoController(BaseIoController):
     def __init__(self):

--- a/tests/source/test_controllers_py/TestControllersPy.cpp
+++ b/tests/source/test_controllers_py/TestControllersPy.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(TestControllersPy, TestControllers)
+PYBIND11_MODULE(test_controllers_py, TestControllers)
 {
     py::class_<meen::MemoryController, meen::IController>(TestControllers, "MemoryController")
         .def(py::init<>())


### PR DESCRIPTION
When the Conan option `with_python` is specified the generated output libraries are now named using snake_case instead of camelCase.