### PR TITLE
#275 chore: update dependency version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * MEEN pybind library names now use snake_case instead of
   CamelCase.
 * Updated GTest dependency to 1.16.0.
-* Updated PyBind dependency to 2.13.6.
+* Updated pybind11 dependency to 2.13.6.
 
 2.0.0 [22/06/25]
 * Updated the project layout for improved workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Now using ArduinoJson exclusively.
 * MEEN pybind library names now use snake_case instead of
   CamelCase.
+* Updated GTest dependency to 1.16.0.
+* Updated PyBind dependency to 2.13.6.
 
 2.0.0 [22/06/25]
 * Updated the project layout for improved workflow.

--- a/README.md
+++ b/README.md
@@ -158,11 +158,10 @@ The following will enable python and disable zlib: `conan install . --build=miss
 
 The following dependent packages will be (compiled if required and) installed based on the supplied options:
 
-- `arduinojson`: for parsing machine configuration options  (baremetal).
+- `arduinojson`: for parsing machine configuration options.
 - `base64`: for base64 coding.
 - `gtest`: for running the MEEN unit tests.
 - `hash-library`: for md5 hashing.
-- `nlohmann_json`: for parsing machine configuration options.
 - `pybind`: for creating Python C++ bindings.
 - `unity`: for running the MEEN unit tests (baremetal).
 - `zlib`: for memory (de)compression when loading and saving files.<br>

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The following dependent packages will be (compiled if required and) installed ba
 - `base64`: for base64 coding.
 - `gtest`: for running the MEEN unit tests.
 - `hash-library`: for md5 hashing.
-- `pybind`: for creating Python C++ bindings.
+- `pybind11`: for creating Python C++ bindings.
 - `unity`: for running the MEEN unit tests (baremetal).
 - `zlib`: for memory (de)compression when loading and saving files.<br>
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -66,14 +66,14 @@ class MeenRecipe(ConanFile):
             self.requires("hash-library/8.0")
 
         if self.options.get_safe("with_python", False):
-            self.requires("pybind11/2.12.0")
+            self.requires("pybind11/2.13.6")
         if self.options.get_safe("with_zlib", False):
             self.requires("zlib/1.3.1")
 
     def build_requirements(self):
         if not self.conf.get("tools.build:skip_test", default=False):
             if self.options.get_safe("with_framework", "none") == "gtest":
-                self.test_requires("gtest/1.14.0")
+                self.test_requires("gtest/1.16.0")
             elif self.options.get_safe("with_framework", "none") == "unity":
                 self.test_requires("unity/2.6.0")
 


### PR DESCRIPTION
All dependencies are now at their current latest versions. The following dependencies have been updated:
- GTest: version 1.14.0 -> 1.16.0
- pybind11: version 2.12.0 ->2.13.6