### PR TITLE
#288 fix: icpu return value updates

### DIFF
--- a/include/meen/Error.h
+++ b/include/meen/Error.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2026 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ namespace meen
 		busy,					/**< MEEN is currently running */
 		clock_sampling_freq,	/**< The sampling frequency can't be set, either it is too high/low or the host clock can't be queried */
 		cpu,					/**< The cpu is invalid */
+		invalid_instruction,	/**< The cpu attempted to execute an invalid instruction */
 		encoder, 				/**< The binary to text encoding scheme is unknown */
 		incompatible_ram,		/**< The ram to load is not compatible with this component */
 		incompatible_rom,		/**< The rom to load is not compatible with this component */

--- a/include/meen/cpu/8080.h
+++ b/include/meen/cpu/8080.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2026 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -113,7 +113,7 @@ namespace meen
 		//cppcheck-suppress unusedStructMember
 		uint8_t opcode_{};
 #ifdef ENABLE_OPCODE_TABLE 
-		std::unique_ptr<std::function <uint8_t()>[]> opcodeTable_;
+		std::unique_ptr<std::function <int8_t()>[]> opcodeTable_;
 #endif
 		IController* memoryController_{};
 		IController* ioController_{};
@@ -125,82 +125,82 @@ namespace meen
 		static bool Zero(const Register& r) { return r.none(); }
 
 		//Should be implicitly inline
-		inline uint8_t Inr(Register& r);
-		inline uint8_t Inr();
-		inline uint8_t Dcr(Register& r);
-		inline uint8_t Dcr(uint16_t addr);
-		inline uint8_t Mvi(Register& reg);
-		inline uint8_t Mvi();
-		inline uint8_t Daa();
-		inline uint8_t Rlc();
-		inline uint8_t Rrc();
-		inline uint8_t Ral();
-		inline uint8_t Rar();
-		inline uint8_t Lxi(Register& regHi, Register& regLow);
-		inline uint8_t Lxi();
-		inline uint8_t Shld();
-		inline uint8_t Stax(const Register& hi, const Register& low);
-		inline uint8_t Inx(Register& hi, Register& low);
-		inline uint8_t Inx();
-		inline uint8_t Dad(const Register& hi, const Register& low);
-		inline uint8_t Dad();
-		inline uint8_t Lhld();
-		inline uint8_t Ldax(const Register& hi, const Register& low);
-		inline uint8_t Dcx(Register& hi, Register& low);
-		inline uint8_t Dcx();
-		inline uint8_t Cma();
-		inline uint8_t Sta();
-		inline uint8_t Stc();
-		inline uint8_t Lda();
-		inline uint8_t Cmc();
-		inline uint8_t Mov(Register& lhs, const Register& rhs);
-		inline uint8_t Mov(Register& lhs);
-		inline uint8_t Mov(uint8_t value);
-		inline uint8_t Nop();
-		inline uint8_t Hlt();
+		inline int8_t Inr(Register& r);
+		inline int8_t Inr();
+		inline int8_t Dcr(Register& r);
+		inline int8_t Dcr(uint16_t addr);
+		inline int8_t Mvi(Register& reg);
+		inline int8_t Mvi();
+		inline int8_t Daa();
+		inline int8_t Rlc();
+		inline int8_t Rrc();
+		inline int8_t Ral();
+		inline int8_t Rar();
+		inline int8_t Lxi(Register& regHi, Register& regLow);
+		inline int8_t Lxi();
+		inline int8_t Shld();
+		inline int8_t Stax(const Register& hi, const Register& low);
+		inline int8_t Inx(Register& hi, Register& low);
+		inline int8_t Inx();
+		inline int8_t Dad(const Register& hi, const Register& low);
+		inline int8_t Dad();
+		inline int8_t Lhld();
+		inline int8_t Ldax(const Register& hi, const Register& low);
+		inline int8_t Dcx(Register& hi, Register& low);
+		inline int8_t Dcx();
+		inline int8_t Cma();
+		inline int8_t Sta();
+		inline int8_t Stc();
+		inline int8_t Lda();
+		inline int8_t Cmc();
+		inline int8_t Mov(Register& lhs, const Register& rhs);
+		inline int8_t Mov(Register& lhs);
+		inline int8_t Mov(uint8_t value);
+		inline int8_t Nop();
+		inline int8_t Hlt();
 		inline Register Add(const Register& lhs, const Register& rhs, uint8_t carry, bool setCarryFlag, [[maybe_unused]] std::string_view instructionName);
-		inline uint8_t Add(const Register& r, std::string_view instructionName);
-		inline uint8_t Add(uint16_t addr, std::string_view instructionName);
-		inline uint8_t Adc(const Register& r, std::string_view instructionName);
-		inline uint8_t Adc(uint16_t addr, std::string_view instructionName);
+		inline int8_t Add(const Register& r, std::string_view instructionName);
+		inline int8_t Add(uint16_t addr, std::string_view instructionName);
+		inline int8_t Adc(const Register& r, std::string_view instructionName);
+		inline int8_t Adc(uint16_t addr, std::string_view instructionName);
 		inline Register Sub(const Register& r, uint8_t withCarry, std::string_view instructionName);
-		inline uint8_t Sub(const Register& r, std::string_view instructionName);
-		inline uint8_t Sub(uint16_t addr, std::string_view instructionName);
-		inline uint8_t Sbb(const Register& r, std::string_view instructionName);
-		inline uint8_t Sbb(uint16_t addr, std::string_view instructionName);
+		inline int8_t Sub(const Register& r, std::string_view instructionName);
+		inline int8_t Sub(uint16_t addr, std::string_view instructionName);
+		inline int8_t Sbb(const Register& r, std::string_view instructionName);
+		inline int8_t Sbb(uint16_t addr, std::string_view instructionName);
 		inline void Ana(const Register& r);
-		inline uint8_t Ana(const Register& r, std::string_view instructionName);
-		inline uint8_t Ana(uint16_t addr, std::string_view instructionName);
+		inline int8_t Ana(const Register& r, std::string_view instructionName);
+		inline int8_t Ana(uint16_t addr, std::string_view instructionName);
 		inline void Xra(const Register& r);
-		inline uint8_t Xra(const Register& r, std::string_view instructionName);
-		inline uint8_t Xra(uint16_t addr, std::string_view instructionName);
+		inline int8_t Xra(const Register& r, std::string_view instructionName);
+		inline int8_t Xra(uint16_t addr, std::string_view instructionName);
 		inline void Ora(const Register& r);
-		inline uint8_t Ora(const Register& r, std::string_view instructionName);
-		inline uint8_t Ora(uint16_t addr, std::string_view instructionName);
-		inline uint8_t Cmp(const Register& r, std::string_view instructionName);
-		inline uint8_t Cmp(uint16_t addr, std::string_view instructionName);
-		inline uint8_t NotImplemented();
-		inline uint8_t RetOnFlag(bool status, std::string_view instructionName);
-		inline uint8_t Pop(Register& hi, Register& low);
-		inline uint8_t JmpOnFlag(bool status, std::string_view instructionName);
-		inline uint8_t CallOnFlag(bool status, std::string_view instructionName);
-		inline uint8_t Push(const Register& hi, const Register& low);
-		inline uint8_t Adi(const Register& r);
-		inline uint8_t Rst();
-		inline uint8_t Rst(uint8_t restart);
-		inline uint8_t Out();
-		inline uint8_t In();
-		inline uint8_t Xthl();
-		inline uint8_t Pchl();
-		inline uint8_t Xchg();
-		inline uint8_t Di();
-		inline uint8_t Sphl();
-		inline uint8_t Ei();
+		inline int8_t Ora(const Register& r, std::string_view instructionName);
+		inline int8_t Ora(uint16_t addr, std::string_view instructionName);
+		inline int8_t Cmp(const Register& r, std::string_view instructionName);
+		inline int8_t Cmp(uint16_t addr, std::string_view instructionName);
+		inline int8_t NotImplemented();
+		inline int8_t RetOnFlag(bool status, std::string_view instructionName);
+		inline int8_t Pop(Register& hi, Register& low);
+		inline int8_t JmpOnFlag(bool status, std::string_view instructionName);
+		inline int8_t CallOnFlag(bool status, std::string_view instructionName);
+		inline int8_t Push(const Register& hi, const Register& low);
+		inline int8_t Adi(const Register& r);
+		inline int8_t Rst();
+		inline int8_t Rst(uint8_t restart);
+		inline int8_t Out();
+		inline int8_t In();
+		inline int8_t Xthl();
+		inline int8_t Pchl();
+		inline int8_t Xchg();
+		inline int8_t Di();
+		inline int8_t Sphl();
+		inline int8_t Ei();
 
 	public:
 		/* I8080 overrides */
-		uint8_t Execute() final;
-		uint8_t Interrupt(ISR isr);
+		int8_t Execute() final;
+		int8_t Interrupt(ISR isr);
 		std::error_code Load(const std::string&& json, bool checkUuid) final;
 #ifdef ENABLE_MEEN_SAVE
 		std::expected<std::string, std::error_code> Save() const final;

--- a/include/meen/cpu/ICpu.h
+++ b/include/meen/cpu/ICpu.h
@@ -41,9 +41,9 @@ namespace meen
 		virtual void SetIoController(IController* ioController) = 0;
 
 		//Executes the next instruction
-		virtual uint8_t Execute() = 0;
+		virtual int8_t Execute() = 0;
 
-		virtual uint8_t Interrupt(ISR isr) = 0;
+		virtual int8_t Interrupt(ISR isr) = 0;
 
 		virtual void Reset() = 0;
 

--- a/include/meen/cpu/Z80.h
+++ b/include/meen/cpu/Z80.h
@@ -38,8 +38,8 @@ namespace meen
 			Intel8080 i8080_;
 		public:
 			/* I8080 overrides */
-			uint8_t Execute() final;
-			uint8_t Interrupt(ISR isr);
+			int8_t Execute() final;
+			int8_t Interrupt(ISR isr);
 			std::error_code Load(const std::string&& json, bool checkUuid) final;
 #ifdef ENABLE_MEEN_SAVE
 			std::expected<std::string, std::error_code> Save() const final;

--- a/source/cpu/8080.cpp
+++ b/source/cpu/8080.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2026 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,7 @@ namespace meen
 Intel8080::Intel8080()
 {
 #ifdef ENABLE_OPCODE_TABLE
-	opcodeTable_ = std::unique_ptr<std::function <uint8_t()>[]>(new std::function <uint8_t()>[256]
+	opcodeTable_ = std::unique_ptr<std::function <int8_t()>[]>(new std::function <int8_t()>[256]
 	{
 		[&] { return Nop(); },
 		[&] { return Lxi(b_, c_); },
@@ -451,9 +451,9 @@ std::expected<std::string, std::error_code> Intel8080::Save() const
 }
 #endif // ENABLE_MEEN_SAVE
 
-uint8_t Intel8080::Interrupt(ISR isr)
+int8_t Intel8080::Interrupt(ISR isr)
 {
-	uint8_t timePeriods = 0;
+	int8_t timePeriods = 0;
 
 	if (iff_ == true)
 	{
@@ -467,11 +467,11 @@ uint8_t Intel8080::Interrupt(ISR isr)
 	return timePeriods;
 }
 
-uint8_t Intel8080::Execute()
+int8_t Intel8080::Execute()
 {
 	if (hlt_ == true)
 	{
-		return 0;//Nop(); // Do we return Nop() here??, 0 is a cpu stall, Nop() will tick the clock but won't execute instrutions
+		return 0;//Nop(); // Do we return Nop() here??, 0 is a cpu stall, Nop() will tick the clock but won't execute instructions
 	}
 
 	opcode_ = memoryController_->Read(pc_, ioController_);
@@ -479,7 +479,7 @@ uint8_t Intel8080::Execute()
 #ifdef ENABLE_OPCODE_TABLE
 	return opcodeTable_[opcode_]();
 #else
-	uint8_t timePeriods = 0;
+	int8_t timePeriods = 0;
 
 	switch(opcode_)
 	{
@@ -739,7 +739,7 @@ uint8_t Intel8080::Execute()
 		case 0xFD: timePeriods = NotImplemented(); break;
 		case 0xFE: timePeriods = Cmp(++pc_, "CPI"); break;
 		case 0xFF: timePeriods = Rst(); break;
-		default: assert(0); break;
+		default: assert(0); timePeriods = NotImplemented(); break;
 	}
 
 	return timePeriods;
@@ -778,13 +778,13 @@ void Intel8080::Reset()
 
 	The specified register or memory byte is incremented by one.
 */
-uint8_t Intel8080::Inr(Register& r)
+int8_t Intel8080::Inr(Register& r)
 {
 	r = Add(r, 0x01, 0, false, "INR");
 	return 5;
 }
 
-uint8_t Intel8080::Inr()
+int8_t Intel8080::Inr()
 {
 	auto addr = Uint16(h_, l_);
 	Register r = memoryController_->Read(addr, ioController_);
@@ -800,14 +800,14 @@ uint8_t Intel8080::Inr()
 	The specified register or memory byte is
 	decremented by one.
 */
-uint8_t Intel8080::Dcr(Register& r)
+int8_t Intel8080::Dcr(Register& r)
 {
 	//Using twos compliment add for subtraciton.
 	r = Add(r, 0xFF, 0, false, "DCR");
 	return 5;
 }
 
-uint8_t Intel8080::Dcr(uint16_t addr)
+int8_t Intel8080::Dcr(uint16_t addr)
 {
 	Register r = memoryController_->Read(addr, ioController_);
 	r = Add(r, 0xFF, 0, false, "DCR");
@@ -816,7 +816,7 @@ uint8_t Intel8080::Dcr(uint16_t addr)
 	return 10;
 }
 
-uint8_t Intel8080::Mvi(Register& reg)
+int8_t Intel8080::Mvi(Register& reg)
 {
 	reg = memoryController_->Read(++pc_, ioController_);
 
@@ -829,7 +829,7 @@ uint8_t Intel8080::Mvi(Register& reg)
 	return 7;
 }
 
-uint8_t Intel8080::Mvi()
+int8_t Intel8080::Mvi()
 {
 	auto data = memoryController_->Read(++pc_, ioController_);
 	auto addr = Uint16(h_, l_);
@@ -851,7 +851,7 @@ uint8_t Intel8080::Mvi()
 	accumulator is adjusted to form two four bit
 	binary-coded-decimal digits.
 */
-uint8_t Intel8080::Daa()
+int8_t Intel8080::Daa()
 {
 	if constexpr (dbg == true)
 	{
@@ -885,7 +885,7 @@ uint8_t Intel8080::Daa()
 	with the high order bit being transferred to the low-order bit position of
 	the accumulator.
 */
-uint8_t Intel8080::Rlc()
+int8_t Intel8080::Rlc()
 {
 	if constexpr (dbg == true)
 	{
@@ -907,7 +907,7 @@ uint8_t Intel8080::Rlc()
 	rotated one bit position to the right, with the low-order bit
 	being transferred to the high-order bit position of the accumulator.
 */
-uint8_t Intel8080::Rrc()
+int8_t Intel8080::Rrc()
 {
 	if constexpr (dbg == true)
 	{
@@ -929,7 +929,7 @@ uint8_t Intel8080::Rrc()
 	Carry bit, while the Carry bit replaces the high-order bit of
 	the accumulator.
 */
-uint8_t Intel8080::Ral()
+int8_t Intel8080::Ral()
 {
 	if constexpr (dbg == true)
 	{
@@ -952,7 +952,7 @@ uint8_t Intel8080::Ral()
 	carry bit, while the carry bit replaces the high-order bit of
 	the accumulator.
 */
-uint8_t Intel8080::Rar()
+int8_t Intel8080::Rar()
 {
 	if constexpr (dbg == true)
 	{
@@ -967,7 +967,7 @@ uint8_t Intel8080::Rar()
 	return 4;
 }
 
-uint8_t Intel8080::Lxi(Register& regHi, Register& regLow)
+int8_t Intel8080::Lxi(Register& regHi, Register& regLow)
 {
 	regLow = memoryController_->Read(++pc_, ioController_);
 	regHi = memoryController_->Read(++pc_, ioController_);
@@ -981,7 +981,7 @@ uint8_t Intel8080::Lxi(Register& regHi, Register& regLow)
 	return 10;
 }
 
-uint8_t Intel8080::Lxi()
+int8_t Intel8080::Lxi()
 {
 	auto spLow = memoryController_->Read(++pc_, ioController_);
 	sp_ = Uint16(memoryController_->Read(++pc_, ioController_), spLow);
@@ -1003,7 +1003,7 @@ uint8_t Intel8080::Lxi()
 	with LOW ADO. The contents of the H register are stored at
 	the next higher memory address.
 */
-uint8_t Intel8080::Shld()
+int8_t Intel8080::Shld()
 {
 	auto addrLow = memoryController_->Read(++pc_, ioController_);
 	uint16_t addr = Uint16(memoryController_->Read(++pc_, ioController_), addrLow);
@@ -1032,7 +1032,7 @@ uint8_t Intel8080::Shld()
 	16H, the instruction: STAX B
 	will store the contents of the accumulator at memory location 3F16H.
 */
-uint8_t Intel8080::Stax(const Register& hi, const Register& low)
+int8_t Intel8080::Stax(const Register& hi, const Register& low)
 {
 	if constexpr (dbg == true)
 	{
@@ -1050,7 +1050,7 @@ uint8_t Intel8080::Stax(const Register& hi, const Register& low)
 	The 16-bit number held in the specified
 	register pair is incremented by one.
 */
-uint8_t Intel8080::Inx(Register& hi, Register& low)
+int8_t Intel8080::Inx(Register& hi, Register& low)
 {
 	if constexpr (dbg == true)
 	{
@@ -1064,7 +1064,7 @@ uint8_t Intel8080::Inx(Register& hi, Register& low)
 	return 5;
 }
 
-uint8_t Intel8080::Inx()
+int8_t Intel8080::Inx()
 {
 	if constexpr (dbg == true)
 	{
@@ -1083,7 +1083,7 @@ uint8_t Intel8080::Inx()
 	registers using two's complement arithmetic. The result replaces the contents of
 	the H and L registers.
 */
-uint8_t Intel8080::Dad(const Register& hi, const Register& low)
+int8_t Intel8080::Dad(const Register& hi, const Register& low)
 {
 	if constexpr (dbg == true)
 	{
@@ -1105,7 +1105,7 @@ uint8_t Intel8080::Dad(const Register& hi, const Register& low)
 	return 10;
 }
 
-uint8_t Intel8080::Dad()
+int8_t Intel8080::Dad()
 {
 	return Dad((sp_ >> 8) & 0xFF, sp_ & 0xFF);
 }
@@ -1117,7 +1117,7 @@ uint8_t Intel8080::Dad()
 	by concatenating HI ADD with LOW ADD replaces the contents of the L register.
 	The byte at the next higher memory address replaces the contents of the H register.
 */
-uint8_t Intel8080::Lhld()
+int8_t Intel8080::Lhld()
 {
 	auto addrLow = memoryController_->Read(++pc_, ioController_);
 	uint16_t addr = Uint16(memoryController_->Read(++pc_, ioController_), addrLow);
@@ -1139,7 +1139,7 @@ uint8_t Intel8080::Lhld()
 	The contents of the memory location
 	addressed by registers BC/DE replace the contents of the accumulator.
 */
-uint8_t Intel8080::Ldax(const Register& hi, const Register& low)
+int8_t Intel8080::Ldax(const Register& hi, const Register& low)
 {
 	if constexpr (dbg == true)
 	{
@@ -1157,7 +1157,7 @@ uint8_t Intel8080::Ldax(const Register& hi, const Register& low)
 	The 16-bit number held in the specified
 	register pair is decremented by one.
 */
-uint8_t Intel8080::Dcx(Register& hi, Register& low)
+int8_t Intel8080::Dcx(Register& hi, Register& low)
 {
 	if constexpr (dbg == true)
 	{
@@ -1171,7 +1171,7 @@ uint8_t Intel8080::Dcx(Register& hi, Register& low)
 	return 5;
 }
 
-uint8_t Intel8080::Dcx()
+int8_t Intel8080::Dcx()
 {
 	if constexpr (dbg == true)
 	{
@@ -1188,7 +1188,7 @@ uint8_t Intel8080::Dcx()
 
 	Each bit of the contents of the accumulator is complemented (producing the one's complement).
 */
-uint8_t Intel8080::Cma()
+int8_t Intel8080::Cma()
 {
 	if constexpr (dbg == true)
 	{
@@ -1200,7 +1200,7 @@ uint8_t Intel8080::Cma()
 	return 4;
 }
 
-uint8_t Intel8080::Sta()
+int8_t Intel8080::Sta()
 {
 	auto addrLow = memoryController_->Read(++pc_, ioController_);
 	uint16_t addr = Uint16(memoryController_->Read(++pc_, ioController_), addrLow);
@@ -1215,7 +1215,7 @@ uint8_t Intel8080::Sta()
 	return 13;
 }
 
-uint8_t Intel8080::Stc()
+int8_t Intel8080::Stc()
 {
 	if constexpr (dbg == true)
 	{
@@ -1227,7 +1227,7 @@ uint8_t Intel8080::Stc()
 	return 4;
 }
 
-uint8_t Intel8080::Lda()
+int8_t Intel8080::Lda()
 {
 	auto addrLow = memoryController_->Read(++pc_, ioController_);
 	uint16_t addr = Uint16(memoryController_->Read(++pc_, ioController_), addrLow);
@@ -1242,7 +1242,7 @@ uint8_t Intel8080::Lda()
 	return 13;
 }
 
-uint8_t Intel8080::Cmc()
+int8_t Intel8080::Cmc()
 {
 	if constexpr (dbg == true)
 	{
@@ -1254,7 +1254,7 @@ uint8_t Intel8080::Cmc()
 	return 4;
 }
 
-uint8_t Intel8080::Mov(Register& lhs, const Register& rhs)
+int8_t Intel8080::Mov(Register& lhs, const Register& rhs)
 {
 	if constexpr (dbg == true)
 	{
@@ -1266,7 +1266,7 @@ uint8_t Intel8080::Mov(Register& lhs, const Register& rhs)
 	return 5;
 }
 
-uint8_t Intel8080::Mov(Register& lhs)
+int8_t Intel8080::Mov(Register& lhs)
 {
 	auto addr = Uint16(h_, l_);
 
@@ -1280,7 +1280,7 @@ uint8_t Intel8080::Mov(Register& lhs)
 	return 7;
 }
 
-uint8_t Intel8080::Mov(uint8_t value)
+int8_t Intel8080::Mov(uint8_t value)
 {
 	uint16_t addr = Uint16(h_, l_);
 
@@ -1294,7 +1294,7 @@ uint8_t Intel8080::Mov(uint8_t value)
 	return 7;
 }
 
-uint8_t Intel8080::Nop()
+int8_t Intel8080::Nop()
 {
 	if constexpr (dbg == true)
 	{
@@ -1322,7 +1322,7 @@ uint8_t Intel8080::Nop()
 	to ignore interrupts, the computer will not operate again
 	until the main power switch is turned off and then back on.
 */
-uint8_t Intel8080::Hlt()
+int8_t Intel8080::Hlt()
 {
 	if constexpr (dbg == true)
 	{
@@ -1353,25 +1353,25 @@ Intel8080::Register Intel8080::Add(const Register& lhs, const Register& rhs, uin
 	return r;
 }
 
-uint8_t Intel8080::Add(const Register& r, std::string_view instructionName)
+int8_t Intel8080::Add(const Register& r, std::string_view instructionName)
 {
 	a_ = Add(a_, r, 0, true, instructionName);
 	return 4;
 }
 
-uint8_t Intel8080::Add(uint16_t addr, std::string_view instructionName)
+int8_t Intel8080::Add(uint16_t addr, std::string_view instructionName)
 {
 	a_ = Add(a_, Register(memoryController_->Read(addr, ioController_)), 0, true, instructionName);
 	return 7;
 }
 
-uint8_t Intel8080::Adc(const Register& r, std::string_view instructionName)
+int8_t Intel8080::Adc(const Register& r, std::string_view instructionName)
 {
 	a_ = Add(a_, r, status_[Condition::CarryFlag], true, instructionName);
 	return 4;
 }
 
-uint8_t Intel8080::Adc(uint16_t addr, std::string_view instructionName)
+int8_t Intel8080::Adc(uint16_t addr, std::string_view instructionName)
 {
 	a_ = Add(a_, Register(memoryController_->Read(addr, ioController_)), status_[Condition::CarryFlag], true, instructionName);
 	return 7;
@@ -1384,25 +1384,25 @@ Intel8080::Register Intel8080::Sub(const Register& r, uint8_t withCarry, std::st
 	return reg;
 }
 
-uint8_t Intel8080::Sub(const Register& r, std::string_view instructionName)
+int8_t Intel8080::Sub(const Register& r, std::string_view instructionName)
 {
 	a_ = Sub(r, 0, instructionName);
 	return 4;
 }
 
-uint8_t Intel8080::Sub(uint16_t addr, std::string_view instructionName)
+int8_t Intel8080::Sub(uint16_t addr, std::string_view instructionName)
 {
 	a_ = Sub(Register(memoryController_->Read(addr, ioController_)), 0, instructionName);
 	return 7;
 }
 
-uint8_t Intel8080::Sbb(const Register& r, std::string_view instructionName)
+int8_t Intel8080::Sbb(const Register& r, std::string_view instructionName)
 {
 	a_ = Sub(r, status_[Condition::CarryFlag], instructionName);
 	return 4;
 }
 
-uint8_t Intel8080::Sbb(uint16_t addr, std::string_view instructionName)
+int8_t Intel8080::Sbb(uint16_t addr, std::string_view instructionName)
 {
 	a_ = Sub(Register(memoryController_->Read(addr, ioController_)), status_[Condition::CarryFlag], instructionName);
 	return 7;
@@ -1421,7 +1421,7 @@ void Intel8080::Ana(const Register& r)
 	pc_++;
 }
 
-uint8_t Intel8080::Ana(const Register& r, std::string_view instructionName)
+int8_t Intel8080::Ana(const Register& r, std::string_view instructionName)
 {
 	if constexpr (dbg == true)
 	{
@@ -1432,7 +1432,7 @@ uint8_t Intel8080::Ana(const Register& r, std::string_view instructionName)
 	return 4;
 }
 
-uint8_t Intel8080::Ana(uint16_t addr, std::string_view instructionName)
+int8_t Intel8080::Ana(uint16_t addr, std::string_view instructionName)
 {
 	Register r = memoryController_->Read(addr, ioController_);
 
@@ -1464,7 +1464,7 @@ void Intel8080::Xra(const Register& r)
 	pc_++;
 }
 
-uint8_t Intel8080::Xra(const Register& r, std::string_view instructionName)
+int8_t Intel8080::Xra(const Register& r, std::string_view instructionName)
 {
 	if constexpr (dbg == true)
 	{
@@ -1475,7 +1475,7 @@ uint8_t Intel8080::Xra(const Register& r, std::string_view instructionName)
 	return 4;
 }
 
-uint8_t Intel8080::Xra(uint16_t addr, std::string_view instructionName)
+int8_t Intel8080::Xra(uint16_t addr, std::string_view instructionName)
 {
 	Register r = memoryController_->Read(addr, ioController_);
 
@@ -1507,7 +1507,7 @@ void Intel8080::Ora(const Register& r)
 	pc_++;
 }
 
-uint8_t Intel8080::Ora(const Register& r, std::string_view instructionName)
+int8_t Intel8080::Ora(const Register& r, std::string_view instructionName)
 {
 	if constexpr (dbg == true)
 	{
@@ -1518,7 +1518,7 @@ uint8_t Intel8080::Ora(const Register& r, std::string_view instructionName)
 	return 4;
 }
 
-uint8_t Intel8080::Ora(uint16_t addr, std::string_view instructionName)
+int8_t Intel8080::Ora(uint16_t addr, std::string_view instructionName)
 {
 	Register r = memoryController_->Read(addr, ioController_);
 
@@ -1538,40 +1538,40 @@ uint8_t Intel8080::Ora(uint16_t addr, std::string_view instructionName)
 	return 7;
 }
 
-uint8_t Intel8080::Cmp(const Register& r, std::string_view instructionName)
+int8_t Intel8080::Cmp(const Register& r, std::string_view instructionName)
 {
 	Sub(r, 0, instructionName);
 	return 4;
 }
 
-uint8_t Intel8080::Cmp(uint16_t addr, std::string_view instructionName)
+int8_t Intel8080::Cmp(uint16_t addr, std::string_view instructionName)
 {
 	Register r = memoryController_->Read(addr, ioController_);
 	Sub(r, 0, instructionName);
 	return 7;
 }
 
-uint8_t Intel8080::NotImplemented()
+int8_t Intel8080::NotImplemented()
 {
 	if constexpr (dbg == true)
 	{
 		printf("0x%04X Instruction %02X not implemented\n", pc_, opcode_);
 	}
 
-	if (opcode_ == 0xED || opcode_ == 0xFD || opcode_ == 0xDD)
-	{
-		pc_++;
-	}
-	else
-	{
-		assert(0);
-	}
+	//assert(0);
+	//{
+		//pc_++;
+	//}
+	//else
+	//{
+	//	assert(0);
+	//}
 
-	pc_++;
-	return 0;
+	//pc_++;
+	return -1;
 }
 
-uint8_t Intel8080::RetOnFlag(bool status, std::string_view instructionName)
+int8_t Intel8080::RetOnFlag(bool status, std::string_view instructionName)
 {
 	if constexpr (dbg == true)
 	{
@@ -1600,7 +1600,7 @@ uint8_t Intel8080::RetOnFlag(bool status, std::string_view instructionName)
 	}
 }
 
-uint8_t Intel8080::Pop(Register& hi, Register& low)
+int8_t Intel8080::Pop(Register& hi, Register& low)
 {
 	if constexpr (dbg == true)
 	{
@@ -1620,7 +1620,7 @@ uint8_t Intel8080::Pop(Register& hi, Register& low)
 	return 10;
 }
 
-uint8_t Intel8080::JmpOnFlag(bool status, std::string_view instructionName)
+int8_t Intel8080::JmpOnFlag(bool status, std::string_view instructionName)
 {
 	auto addrLow = memoryController_->Read(++pc_, ioController_);
 	auto addr = Uint16(memoryController_->Read(++pc_, ioController_), addrLow);
@@ -1634,7 +1634,7 @@ uint8_t Intel8080::JmpOnFlag(bool status, std::string_view instructionName)
 	return 10;
 }
 
-uint8_t Intel8080::CallOnFlag(bool status, std::string_view instructionName)
+int8_t Intel8080::CallOnFlag(bool status, std::string_view instructionName)
 {
 	auto addrLow = memoryController_->Read(++pc_, ioController_);
 	auto addr = Uint16(memoryController_->Read(++pc_, ioController_), addrLow);
@@ -1669,7 +1669,7 @@ uint8_t Intel8080::CallOnFlag(bool status, std::string_view instructionName)
 	}
 }
 
-uint8_t Intel8080::Push(const Register& hi, const Register& low)
+int8_t Intel8080::Push(const Register& hi, const Register& low)
 {
 	if constexpr (dbg == true)
 	{
@@ -1691,7 +1691,7 @@ uint8_t Intel8080::Push(const Register& hi, const Register& low)
 	return 11;
 }
 
-uint8_t Intel8080::Adi(const Register& r)
+int8_t Intel8080::Adi(const Register& r)
 {
 	if constexpr (dbg == true)
 	{
@@ -1713,7 +1713,7 @@ uint8_t Intel8080::Adi(const Register& r)
 	are pushed onto the stack, providing a return address for
 	later use by a RETURN instruction.
 */
-uint8_t Intel8080::Rst(uint8_t restart)
+int8_t Intel8080::Rst(uint8_t restart)
 {
 	uint16_t addr = restart & 0x38;
 
@@ -1738,7 +1738,7 @@ uint8_t Intel8080::Rst(uint8_t restart)
 	return 11;
 }
 
-uint8_t Intel8080::Rst()
+int8_t Intel8080::Rst()
 {
 	//We need to increment pc_ before the call to Rst as the address of the next
 	//instruction (++pc_) to be executed needs to be pushed to the stack so we
@@ -1771,7 +1771,7 @@ uint8_t Intel8080::Rst()
 	return 11;
 }
 
-uint8_t Intel8080::Out()
+int8_t Intel8080::Out()
 {
 	auto out = memoryController_->Read(++pc_, ioController_);
 
@@ -1786,7 +1786,7 @@ uint8_t Intel8080::Out()
 	return 10;
 }
 
-uint8_t Intel8080::In()
+int8_t Intel8080::In()
 {
 	auto in = memoryController_->Read(++pc_, ioController_);
 
@@ -1808,7 +1808,7 @@ uint8_t Intel8080::In()
 	The contents of the H register are exchanged with the contents of the memory byte whose address is one greater than that held
 	in the stack pointer.
 */
-uint8_t Intel8080::Xthl()
+int8_t Intel8080::Xthl()
 {
 	if constexpr (dbg == true)
 	{
@@ -1840,7 +1840,7 @@ uint8_t Intel8080::Xthl()
 	and the contents of the L register replace the least significant 8 bits of the program counter.
 	This causes program execution to continue at the address contained in the H and L registers
 */
-uint8_t Intel8080::Pchl()
+int8_t Intel8080::Pchl()
 {
 	if constexpr (dbg == true)
 	{
@@ -1851,7 +1851,7 @@ uint8_t Intel8080::Pchl()
 	return 5;
 }
 
-uint8_t Intel8080::Xchg()
+int8_t Intel8080::Xchg()
 {
 	if constexpr (dbg == true)
 	{
@@ -1869,7 +1869,7 @@ Implementation of the DI instruction resets the
 interrupt flip - flop. This causes the computer to ignore
 any subsequent interrupt signals.
 */
-uint8_t Intel8080::Di()
+int8_t Intel8080::Di()
 {
 	if constexpr (dbg == true)
 	{
@@ -1881,7 +1881,7 @@ uint8_t Intel8080::Di()
 	return 4;
 }
 
-uint8_t Intel8080::Sphl()
+int8_t Intel8080::Sphl()
 {
 	if constexpr (dbg == true)
 	{
@@ -1897,7 +1897,7 @@ uint8_t Intel8080::Sphl()
 	Implementation of the EI instruction sets the
 	interrupt flip-flop. This alerts the computer to the presence of interrupts and causes it to respond accordingly
 */
-uint8_t Intel8080::Ei()
+int8_t Intel8080::Ei()
 {
 	if constexpr (dbg == true)
 	{

--- a/source/cpu/Z80.cpp
+++ b/source/cpu/Z80.cpp
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <assert.h>
+
 #include "meen/cpu/Z80.h"
 
 namespace meen
@@ -35,18 +37,45 @@ namespace meen
 	}
 
 	/* I8080 overrides */
-	uint8_t Z80::Execute()
+	int8_t Z80::Execute()
 	{
-		// TODO: Execute needs to return int8_t, that way we can return -1 when we encounter an opcode we don't understand
-
 		auto timePeriods = i8080_.Execute();
 
+		if (timePeriods < 0)
+		{
+			uint8_t opcode = 0;
+			/*
+				Read the next opcode
+			*/
+			switch (opcode)
+			{
+				case 0xCB:
+					break;
+				case 0xDD:
+					break;
+				case 0xED:
+					break;
+				case 0xFD:
+					break;
+				default:
+					assert(0);
+					break;
+			}
+		}
+		
 		return timePeriods;
 	}
 
-	uint8_t Z80::Interrupt(ISR isr)
+	int8_t Z80::Interrupt(ISR isr)
 	{
-		return i8080_.Interrupt(isr);
+		auto timePeriods = i8080_.Interrupt(isr);
+
+		if (timePeriods < 0)
+		{
+			
+		}
+
+		return timePeriods;
 	}
 
 	std::error_code Z80::Load(const std::string&& json, bool checkUuid)

--- a/source/machine/Machine.cpp
+++ b/source/machine/Machine.cpp
@@ -841,8 +841,17 @@ namespace meen
 				case ISR::Seven:
 				{
 					ticks = m->cpu_->Interrupt(isr);
-					currTime = m->clock_->Tick(ticks);
-					totalTicks += ticks;
+
+					if (ticks >= 0)
+					{
+						currTime = m->clock_->Tick(ticks);
+						totalTicks += ticks;
+					}
+					else
+					{
+						// Call the on error handler if it has been set to indicate we have encountered an instruction we don't understand
+						m->HandleError(errc::invalid_instruction, std::source_location::current());
+					}
 					break;
 				}
 				case ISR::Load:
@@ -1142,11 +1151,23 @@ namespace meen
 			{
 				//Execute the next instruction
 				ticks = m->cpu_->Execute();
-				currTime = m->clock_->Tick(ticks);
-				totalTicks += ticks;
+
+				// We can return megative here, we don't want to rewind the clock
+				if (ticks >= 0)
+				{
+					currTime = m->clock_->Tick(ticks);
+					totalTicks += ticks;
+				}
+				else
+				{
+					// Call the on error handler if it has been set to indicate we have encountered an instruction we don't understand
+					m->HandleError(errc::invalid_instruction, std::source_location::current());
+				}
 
 				// Check if it is time to service interrupts
-				if (totalTicks - lastTicks >= ticksPerIsr || ticks == 0) // when ticks is 0 the cpu is not executing (it has been halted), poll (should be less aggressive) for interrupts to unhalt the cpu
+				// When ticks is 0 the cpu is not executing (it has been halted), poll (should be less aggressive) for interrupts to unhalt the cpu
+				// When ticks is < 0 we are stuck on an instruction we don't understand, give the interrupt system some chance to take action
+				if (totalTicks - lastTicks >= ticksPerIsr || ticks <= 0)
 				{
 					quit = serviceInterrupts();
 					lastTicks = totalTicks;

--- a/source/utils/ErrorCode.cpp
+++ b/source/utils/ErrorCode.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2026 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,8 @@ namespace meen
 						return "the host clock sampling frequency can't be set, either it's too high/low or the host clock can't be queried";
 					case errc::cpu:
 						return "the cpu is invalid";
+					case errc::invalid_instruction:
+						return "the cpu attempted to execute an invalid instruction";
 					case errc::encoder:
 						return "the binary to text encoder is unknown";
 					case errc::incompatible_ram:


### PR DESCRIPTION
- Update the ICPU methods Interrupt and Execute to return int8_t rather than uint8_t. This allows those methods to be checked against < 0 so we can determine whether or not the next cpu instruction was executed.
When the cpu fails to execute the instruction the instruction pointer remains unchanged, ie; repeated calls to Interrupt or Execute will repeatedly attempt to execute the unknown instruction.
When the machine encounters this it will call the on error method (if registered) with the meen::errc::invalid_instruction error code and will then call the interrupt system so it can deal with the situation.

- Also fleshed out the z80 stubs a little more to handle this.